### PR TITLE
[feat.] Add layout customization, compact widget, and usage display fixes

### DIFF
--- a/scripts/jsonl-summary.test.mjs
+++ b/scripts/jsonl-summary.test.mjs
@@ -14,6 +14,10 @@ function tempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'wmt-jsonl-summary-'));
 }
 
+function recentTimestamp(offsetMs = 0) {
+  return new Date(Date.now() - 60_000 + offsetMs).toISOString();
+}
+
 function claudeAssistantLine({ id, timestamp, model = 'claude-sonnet-4', input = 10, output = 20, cacheCreation = 0, cacheRead = 0 }) {
   return JSON.stringify({
     type: 'assistant',
@@ -39,7 +43,7 @@ test('streaming summary scan does not use full readFileSync for JSONL bodies', a
   cache.clearAll();
   const dir = tempDir();
   const filePath = path.join(dir, 'claude.jsonl');
-  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'a', timestamp: '2026-04-24T00:00:00.000Z' })}\n`, 'utf8');
+  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'a', timestamp: recentTimestamp() })}\n`, 'utf8');
 
   const originalReadFileSync = fs.readFileSync;
   fs.readFileSync = function patchedReadFileSync(target, ...args) {
@@ -64,7 +68,7 @@ test('unchanged file reuses cached summary without reopening the stream', async 
   cache.clearAll();
   const dir = tempDir();
   const filePath = path.join(dir, 'cached.jsonl');
-  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'cache-hit', timestamp: '2026-04-24T00:00:00.000Z' })}\n`, 'utf8');
+  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'cache-hit', timestamp: recentTimestamp() })}\n`, 'utf8');
 
   await scanJsonlSummaryCached(filePath, 'claude', cache, true);
 
@@ -90,10 +94,10 @@ test('Claude duplicate request updates output delta without double counting', as
   cache.clearAll();
   const dir = tempDir();
   const filePath = path.join(dir, 'duplicate.jsonl');
-  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'dup-1', timestamp: '2026-04-24T00:00:00.000Z', output: 10 })}\n`, 'utf8');
+  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'dup-1', timestamp: recentTimestamp(), output: 10 })}\n`, 'utf8');
 
   await scanJsonlSummaryCached(filePath, 'claude', cache, true);
-  fs.appendFileSync(filePath, `${claudeAssistantLine({ id: 'dup-1', timestamp: '2026-04-24T00:00:01.000Z', output: 25 })}\n`, 'utf8');
+  fs.appendFileSync(filePath, `${claudeAssistantLine({ id: 'dup-1', timestamp: recentTimestamp(1_000), output: 25 })}\n`, 'utf8');
 
   const summary = await scanJsonlSummaryCached(filePath, 'claude', cache, false);
 
@@ -107,8 +111,8 @@ test('malformed trailing JSONL text is recovered on append', async () => {
   const dir = tempDir();
   const filePath = path.join(dir, 'trailing.jsonl');
 
-  const first = claudeAssistantLine({ id: 'first', timestamp: '2026-04-24T00:00:00.000Z', output: 10 });
-  const partialPrefix = '{"type":"assistant","timestamp":"2026-04-24T00:00:01.000Z","message":{"id":"second","model":"claude-sonnet-4","usage":{"input_tokens":10';
+  const first = claudeAssistantLine({ id: 'first', timestamp: recentTimestamp(), output: 10 });
+  const partialPrefix = `{"type":"assistant","timestamp":"${recentTimestamp(1_000)}","message":{"id":"second","model":"claude-sonnet-4","usage":{"input_tokens":10`;
   fs.writeFileSync(filePath, `${first}\n${partialPrefix}`, 'utf8');
 
   const firstSummary = await scanJsonlSummaryCached(filePath, 'claude', cache, true);

--- a/scripts/rate-limit-fetcher.test.mjs
+++ b/scripts/rate-limit-fetcher.test.mjs
@@ -137,7 +137,7 @@ test('Claude API reports schema changes when core window fields have invalid typ
   assert.match(result.status.detail, /invalid core usage fields/i);
 });
 
-test('Claude API keeps core usage when only Sonnet window is malformed', async () => {
+test('Claude API treats utilization as percentage units when only Sonnet window is malformed', async () => {
   withMockCredentials();
   withHttpResponse(200, {
     five_hour: { utilization: 0.03, resets_at: '2026-04-24T05:00:00.000Z' },
@@ -149,10 +149,27 @@ test('Claude API keeps core usage when only Sonnet window is malformed', async (
 
   assert.ok(result.usage);
   assert.equal(result.status.code, 'reset-unavailable');
-  assert.equal(result.usage.h5Pct, 3);
-  assert.equal(result.usage.weekPct, 40);
+  assert.equal(result.usage.h5Pct, 0.03);
+  assert.equal(result.usage.weekPct, 0.4);
   assert.equal(result.usage.soPct, 0);
   assert.equal(result.usage.soResetMs, null);
+});
+
+test('Claude API does not inflate sub-one-percent usage to near full', async () => {
+  withMockCredentials();
+  withHttpResponse(200, {
+    five_hour: { utilization: 0.98, resets_at: '2026-04-24T05:00:00.000Z' },
+    seven_day: { utilization: 1.4, resets_at: '2026-04-28T00:00:00.000Z' },
+    seven_day_sonnet: { utilization: 0.2, resets_at: '2026-04-28T00:00:00.000Z' },
+  });
+
+  const result = await fetchApiUsagePct();
+
+  assert.ok(result.usage);
+  assert.equal(result.status.code, 'ok');
+  assert.equal(result.usage.h5Pct, 0.98);
+  assert.equal(result.usage.weekPct, 1.4);
+  assert.equal(result.usage.soPct, 0.2);
 });
 
 test('Claude API reports missing credentials without throwing', async () => {
@@ -185,10 +202,10 @@ test('persisted Claude API cache is normalized before reuse', () => {
   });
 
   assert.ok(normalized);
-  assert.equal(normalized.h5Pct, 63);
+  assert.equal(normalized.h5Pct, 0.63);
   assert.equal(normalized.h5ResetMs, null);
   assert.equal(normalized.weekResetMs, 1200);
-  assert.equal(normalized.extraUsage?.utilization, 100);
+  assert.equal(normalized.extraUsage?.utilization, 1);
   assert.equal(normalized.storedAt, undefined);
 });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,7 @@ let popupMoving = false;
 let popupMoveEndTimer: NodeJS.Timeout | null = null;
 let lastTrayTitle = '';
 let lastTrayTooltip = '';
+let registeredGlobalHotkey = '';
 
 function registerDebugTargets() {
   setListenerTargetsProvider(() => ([
@@ -99,14 +100,15 @@ function createTray(): Tray {
 }
 
 function createPopupWindow(): BrowserWindow {
+  const settings = getSettings();
   const win = new BrowserWindow({
-    width: 420,
-    height: 980,
+    width: 462,
+    height: 1078,
     show: false,
     frame: false,
     resizable: false,
     skipTaskbar: true,
-    alwaysOnTop: true,
+    alwaysOnTop: settings.alwaysOnTop,
     backgroundColor: '#0d0d1a',
     webPreferences: {
       nodeIntegration: false,
@@ -127,6 +129,10 @@ function createPopupWindow(): BrowserWindow {
   return win;
 }
 
+function getSettings(): AppSettings {
+  return { ...DEFAULT_SETTINGS, ...store.store };
+}
+
 function showPopup() {
   if (!popupWindow || popupWindow.isDestroyed()) popupWindow = createPopupWindow();
   if (!tray) return;
@@ -145,6 +151,39 @@ function showPopup() {
     stateUpdateTimer = null;
     popupWindow.webContents.send('state:updated', currentState);
   }
+}
+
+function togglePopupFromShortcut() {
+  if (popupWindow?.isVisible() && popupWindow.isFocused()) {
+    popupWindow.hide();
+    return;
+  }
+  showPopup();
+}
+
+function applyWindowSettings() {
+  const settings = getSettings();
+  if (popupWindow && !popupWindow.isDestroyed()) {
+    popupWindow.setAlwaysOnTop(settings.alwaysOnTop);
+  }
+}
+
+function registerGlobalHotkey(hotkey: string) {
+  if (registeredGlobalHotkey) {
+    globalShortcut.unregister(registeredGlobalHotkey);
+    registeredGlobalHotkey = '';
+  }
+  if (!hotkey.trim()) return;
+  try {
+    const ok = globalShortcut.register(hotkey, togglePopupFromShortcut);
+    if (ok) registeredGlobalHotkey = hotkey;
+  } catch { /* ignore */ }
+}
+
+function applyRuntimeSettings() {
+  const settings = getSettings();
+  applyWindowSettings();
+  registerGlobalHotkey(settings.globalHotkey);
 }
 
 function buildTrayTitle(state: AppState): string {
@@ -255,7 +294,10 @@ app.whenReady().then(() => {
     store,
     () => manager.getState(),
     () => manager.forceRefresh(),
-    () => manager.applySettingsChange(),
+    () => {
+      manager.applySettingsChange();
+      applyRuntimeSettings();
+    },
     () => manager.getDebugMemSnapshot('ipc'),
   );
 
@@ -268,13 +310,8 @@ app.whenReady().then(() => {
   popupWindow.once('ready-to-show', () => showPopup());
 
   // Global shortcut
-  const settings = { ...DEFAULT_SETTINGS, ...store.store };
-  try {
-    globalShortcut.register(settings.globalHotkey, () => {
-      if (popupWindow?.isVisible()) popupWindow.hide();
-      else showPopup();
-    });
-  } catch { /* ignore */ }
+  const settings = getSettings();
+  registerGlobalHotkey(settings.globalHotkey);
 
   // Auto-start at login
   app.setLoginItemSettings({ openAtLogin: settings.openAtLogin });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Tray, Menu, nativeImage, globalShortcut, ipcMain, nativeTheme } from 'electron';
+import { app, BrowserWindow, Tray, Menu, nativeImage, globalShortcut, ipcMain, nativeTheme, screen } from 'electron';
 import * as path from 'path';
 import Store from 'electron-store';
 import { StateManager, AppState } from './stateManager';
@@ -14,6 +14,7 @@ if (!app.requestSingleInstanceLock()) { app.quit(); process.exit(0); }
 
 let tray: Tray | null = null;
 let popupWindow: BrowserWindow | null = null;
+let widgetWindow: BrowserWindow | null = null;
 let stateManager: StateManager | null = null;
 const store = new Store<AppSettings>() as Store<AppSettings>;
 let pendingStateUpdate: AppState | null = null;
@@ -24,6 +25,11 @@ let lastTrayTitle = '';
 let lastTrayTooltip = '';
 let registeredGlobalHotkey = '';
 
+type AppView = 'main' | 'settings' | 'notifications' | 'help';
+const WIDGET_WIDTH = 250;
+const WIDGET_HEIGHT_SINGLE = 96;
+const WIDGET_HEIGHT_BOTH = 150;
+
 function registerDebugTargets() {
   setListenerTargetsProvider(() => ([
     { name: 'process', emitter: process },
@@ -33,6 +39,8 @@ function registerDebugTargets() {
     { name: 'tray', emitter: tray },
     { name: 'popupWindow', emitter: popupWindow },
     { name: 'popupWebContents', emitter: popupWindow?.webContents },
+    { name: 'widgetWindow', emitter: widgetWindow },
+    { name: 'widgetWebContents', emitter: widgetWindow?.webContents },
   ]));
 }
 
@@ -87,7 +95,7 @@ function createTray(): Tray {
   const t = new Tray(icon);
   t.setToolTip('WhereMyTokens');
   t.setContextMenu(Menu.buildFromTemplate([
-    { label: 'Open WhereMyTokens', click: showPopup },
+    { label: 'Open WhereMyTokens', click: () => showPopup() },
     { type: 'separator' },
     { label: 'Quit', click: () => { app.exit(0); } },
   ]));
@@ -122,6 +130,7 @@ function createPopupWindow(): BrowserWindow {
   win.on('move', markPopupMoving);
   win.on('show', () => stateManager?.setUiVisible(true));
   win.on('hide', () => stateManager?.setUiVisible(false));
+  win.webContents.on('context-menu', openDashboardContextMenu);
   registerDebugTargets();
 
   // blur 시 자동 숨김 없음 — 항상 떠있는 위젯 모드
@@ -129,11 +138,127 @@ function createPopupWindow(): BrowserWindow {
   return win;
 }
 
+function compactWidgetSize(settings: AppSettings): { width: number; height: number } {
+  return {
+    width: WIDGET_WIDTH,
+    height: (settings.provider ?? 'both') === 'both' ? WIDGET_HEIGHT_BOTH : WIDGET_HEIGHT_SINGLE,
+  };
+}
+
+function defaultWidgetPosition(width: number, height: number): { x: number; y: number } {
+  const { workArea } = screen.getPrimaryDisplay();
+  return {
+    x: Math.round(workArea.x + workArea.width - width - 18),
+    y: Math.round(workArea.y + 84),
+  };
+}
+
+function validWidgetPosition(value: AppSettings['compactWidgetBounds']): value is { x: number; y: number } {
+  return !!value
+    && typeof value.x === 'number'
+    && typeof value.y === 'number'
+    && Number.isFinite(value.x)
+    && Number.isFinite(value.y);
+}
+
+function persistWidgetPosition(win: BrowserWindow) {
+  if (win.isDestroyed()) return;
+  const [x, y] = win.getPosition();
+  store.set('compactWidgetBounds', { x, y });
+}
+
+function applyCompactWidgetBounds(settings = getSettings()) {
+  if (!widgetWindow || widgetWindow.isDestroyed()) return;
+  const { width, height } = compactWidgetSize(settings);
+  const [x, y] = widgetWindow.getPosition();
+  widgetWindow.setBounds({ x, y, width, height }, false);
+}
+
+function revealCompactWidget(win = widgetWindow, settings = getSettings()) {
+  if (!win || win.isDestroyed() || !settings.compactWidgetEnabled) return;
+  applyCompactWidgetBounds(settings);
+  win.setAlwaysOnTop(settings.alwaysOnTop);
+  if (!win.isVisible()) win.showInactive();
+  const currentState = stateManager?.getState();
+  if (currentState) win.webContents.send('state:updated', currentState);
+}
+
+function openWidgetContextMenu() {
+  if (!widgetWindow || widgetWindow.isDestroyed()) return;
+  Menu.buildFromTemplate([
+    { label: 'Open dashboard', click: () => showPopup('main') },
+    { label: 'Refresh now', click: () => stateManager?.forceRefresh().catch(() => {}) },
+    { label: 'Settings', click: () => showPopup('settings') },
+    { type: 'separator' },
+    { label: 'Hide widget', click: hideCompactWidget },
+    { type: 'separator' },
+    { label: 'Quit', click: () => { app.exit(0); } },
+  ]).popup({ window: widgetWindow });
+}
+
+function openDashboardContextMenu() {
+  if (!popupWindow || popupWindow.isDestroyed()) return;
+  Menu.buildFromTemplate([
+    { label: 'Hide dashboard', click: () => popupWindow?.hide() },
+    { label: 'Refresh now', click: () => stateManager?.forceRefresh().catch(() => {}) },
+    { label: 'Settings', click: () => showPopup('settings') },
+    { type: 'separator' },
+    { label: 'Show widget', click: showCompactWidget },
+    { type: 'separator' },
+    { label: 'Quit', click: () => { app.exit(0); } },
+  ]).popup({ window: popupWindow });
+}
+
+function createWidgetWindow(): BrowserWindow {
+  const settings = getSettings();
+  const { width, height } = compactWidgetSize(settings);
+  const position = validWidgetPosition(settings.compactWidgetBounds)
+    ? settings.compactWidgetBounds
+    : defaultWidgetPosition(width, height);
+  const win = new BrowserWindow({
+    width,
+    height,
+    x: position.x,
+    y: position.y,
+    show: false,
+    frame: false,
+    resizable: false,
+    skipTaskbar: true,
+    alwaysOnTop: settings.alwaysOnTop,
+    backgroundColor: '#0d0f13',
+    hasShadow: true,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  const rendererPath = path.join(app.getAppPath(), 'dist', 'renderer', 'index.html');
+  win.loadFile(rendererPath, { query: { view: 'widget' } });
+  win.on('move', () => persistWidgetPosition(win));
+  win.once('ready-to-show', () => revealCompactWidget(win));
+  win.webContents.once('did-finish-load', () => revealCompactWidget(win));
+  win.on('closed', () => {
+    if (widgetWindow === win) widgetWindow = null;
+  });
+  win.webContents.on('context-menu', openWidgetContextMenu);
+  registerDebugTargets();
+  return win;
+}
+
 function getSettings(): AppSettings {
   return { ...DEFAULT_SETTINGS, ...store.store };
 }
 
-function showPopup() {
+function sendPopupNavigation(view: AppView) {
+  if (!popupWindow || popupWindow.isDestroyed()) return;
+  const send = () => popupWindow?.webContents.send('app:navigate', view);
+  if (popupWindow.webContents.isLoading()) popupWindow.webContents.once('did-finish-load', send);
+  else send();
+}
+
+function showPopup(view: AppView = 'main') {
   if (!popupWindow || popupWindow.isDestroyed()) popupWindow = createPopupWindow();
   if (!tray) return;
 
@@ -144,6 +269,7 @@ function showPopup() {
   popupWindow.setPosition(x, y);
   popupWindow.show();
   popupWindow.focus();
+  sendPopupNavigation(view);
   const currentState = stateManager?.getState();
   if (currentState) {
     pendingStateUpdate = null;
@@ -151,6 +277,38 @@ function showPopup() {
     stateUpdateTimer = null;
     popupWindow.webContents.send('state:updated', currentState);
   }
+}
+
+function sendWidgetStateUpdate(state: AppState) {
+  if (!widgetWindow || widgetWindow.isDestroyed() || !widgetWindow.isVisible()) return;
+  applyCompactWidgetBounds(state.settings);
+  widgetWindow.webContents.send('state:updated', state);
+}
+
+function syncCompactWidget() {
+  const settings = getSettings();
+  if (!settings.compactWidgetEnabled) {
+    if (widgetWindow && !widgetWindow.isDestroyed()) widgetWindow.close();
+    widgetWindow = null;
+    return;
+  }
+
+  if (!widgetWindow || widgetWindow.isDestroyed()) widgetWindow = createWidgetWindow();
+  revealCompactWidget(widgetWindow, settings);
+}
+
+function hideCompactWidget() {
+  store.set('compactWidgetEnabled', false);
+  syncCompactWidget();
+  stateManager?.applySettingsChange();
+  applyRuntimeSettings();
+}
+
+function showCompactWidget() {
+  store.set('compactWidgetEnabled', true);
+  syncCompactWidget();
+  stateManager?.applySettingsChange();
+  applyRuntimeSettings();
 }
 
 function togglePopupFromShortcut() {
@@ -165,6 +323,9 @@ function applyWindowSettings() {
   const settings = getSettings();
   if (popupWindow && !popupWindow.isDestroyed()) {
     popupWindow.setAlwaysOnTop(settings.alwaysOnTop);
+  }
+  if (widgetWindow && !widgetWindow.isDestroyed()) {
+    widgetWindow.setAlwaysOnTop(settings.alwaysOnTop);
   }
 }
 
@@ -183,6 +344,7 @@ function registerGlobalHotkey(hotkey: string) {
 function applyRuntimeSettings() {
   const settings = getSettings();
   applyWindowSettings();
+  syncCompactWidget();
   registerGlobalHotkey(settings.globalHotkey);
 }
 
@@ -239,6 +401,7 @@ function updateTray(state: AppState) {
   }
 
   queueRendererStateUpdate(state);
+  sendWidgetStateUpdate(state);
   } catch { /* 종료 중 tray/window가 이미 소멸된 경우 무시 */ }
 }
 
@@ -299,11 +462,17 @@ app.whenReady().then(() => {
       applyRuntimeSettings();
     },
     () => manager.getDebugMemSnapshot('ipc'),
+    {
+      openDashboard: () => showPopup('main'),
+      openSettings: () => showPopup('settings'),
+      hideCompactWidget,
+    },
   );
 
   tray = createTray();
   popupWindow = createPopupWindow();
   manager.start();
+  syncCompactWidget();
   app.once('before-quit', () => manager.stop());
 
   // Show popup on first launch (after renderer is ready)
@@ -328,6 +497,24 @@ app.whenReady().then(() => {
 
   // 최소화(숨김) IPC
   ipcMain.handle('window:minimize', () => { popupWindow?.hide(); });
+  ipcMain.handle('window:get-compact-widget-position', () => {
+    if (!widgetWindow || widgetWindow.isDestroyed()) return null;
+    const [x, y] = widgetWindow.getPosition();
+    return { x, y };
+  });
+  ipcMain.handle('window:set-compact-widget-position', (_event, position: { x?: unknown; y?: unknown }) => {
+    if (!widgetWindow || widgetWindow.isDestroyed()) return;
+    if (typeof position?.x !== 'number' || typeof position?.y !== 'number') return;
+    if (!Number.isFinite(position.x) || !Number.isFinite(position.y)) return;
+    const size = compactWidgetSize(getSettings());
+    widgetWindow.setBounds({
+      x: Math.round(position.x),
+      y: Math.round(position.y),
+      width: size.width,
+      height: size.height,
+    });
+    persistWidgetPosition(widgetWindow);
+  });
 
   // 시스템 테마 감지: auto 설정 시 OS 다크모드에 따라 resolve
   function resolveTheme(): 'light' | 'dark' {
@@ -343,9 +530,12 @@ app.whenReady().then(() => {
     if (s.theme === 'auto' && popupWindow && !popupWindow.isDestroyed()) {
       popupWindow.webContents.send('theme:changed', resolveTheme());
     }
+    if (s.theme === 'auto' && widgetWindow && !widgetWindow.isDestroyed()) {
+      widgetWindow.webContents.send('theme:changed', resolveTheme());
+    }
   });
 });
 
 app.on('window-all-closed', () => { /* tray app: do not quit */ });
-app.on('second-instance', showPopup);
+app.on('second-instance', () => showPopup());
 app.on('will-quit', () => globalShortcut.unregisterAll());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -145,7 +145,10 @@ function compactWidgetSize(settings: AppSettings): { width: number; height: numb
   };
 }
 
-function defaultWidgetPosition(width: number, height: number): { x: number; y: number } {
+type WidgetPosition = { x: number; y: number };
+type WidgetSize = { width: number; height: number };
+
+function defaultWidgetPosition(width: number, height: number): WidgetPosition {
   const { workArea } = screen.getPrimaryDisplay();
   return {
     x: Math.round(workArea.x + workArea.width - width - 18),
@@ -153,12 +156,30 @@ function defaultWidgetPosition(width: number, height: number): { x: number; y: n
   };
 }
 
-function validWidgetPosition(value: AppSettings['compactWidgetBounds']): value is { x: number; y: number } {
+function validWidgetPosition(value: AppSettings['compactWidgetBounds']): value is WidgetPosition {
   return !!value
     && typeof value.x === 'number'
     && typeof value.y === 'number'
     && Number.isFinite(value.x)
     && Number.isFinite(value.y);
+}
+
+function constrainWidgetPosition(position: WidgetPosition, size: WidgetSize): WidgetPosition {
+  const display = screen.getDisplayNearestPoint(position);
+  const { workArea } = display;
+  const maxX = workArea.x + Math.max(0, workArea.width - size.width);
+  const maxY = workArea.y + Math.max(0, workArea.height - size.height);
+  return {
+    x: Math.round(Math.min(Math.max(position.x, workArea.x), maxX)),
+    y: Math.round(Math.min(Math.max(position.y, workArea.y), maxY)),
+  };
+}
+
+function resolveWidgetPosition(settings: AppSettings, size: WidgetSize): WidgetPosition {
+  const position = validWidgetPosition(settings.compactWidgetBounds)
+    ? settings.compactWidgetBounds
+    : defaultWidgetPosition(size.width, size.height);
+  return constrainWidgetPosition(position, size);
 }
 
 function persistWidgetPosition(win: BrowserWindow) {
@@ -169,9 +190,11 @@ function persistWidgetPosition(win: BrowserWindow) {
 
 function applyCompactWidgetBounds(settings = getSettings()) {
   if (!widgetWindow || widgetWindow.isDestroyed()) return;
-  const { width, height } = compactWidgetSize(settings);
+  const size = compactWidgetSize(settings);
   const [x, y] = widgetWindow.getPosition();
-  widgetWindow.setBounds({ x, y, width, height }, false);
+  const position = constrainWidgetPosition({ x, y }, size);
+  widgetWindow.setBounds({ ...position, ...size }, false);
+  if (position.x !== x || position.y !== y) store.set('compactWidgetBounds', position);
 }
 
 function revealCompactWidget(win = widgetWindow, settings = getSettings()) {
@@ -211,13 +234,11 @@ function openDashboardContextMenu() {
 
 function createWidgetWindow(): BrowserWindow {
   const settings = getSettings();
-  const { width, height } = compactWidgetSize(settings);
-  const position = validWidgetPosition(settings.compactWidgetBounds)
-    ? settings.compactWidgetBounds
-    : defaultWidgetPosition(width, height);
+  const size = compactWidgetSize(settings);
+  const position = resolveWidgetPosition(settings, size);
   const win = new BrowserWindow({
-    width,
-    height,
+    width: size.width,
+    height: size.height,
     x: position.x,
     y: position.y,
     show: false,
@@ -261,6 +282,7 @@ function sendPopupNavigation(view: AppView) {
 function showPopup(view: AppView = 'main') {
   if (!popupWindow || popupWindow.isDestroyed()) popupWindow = createPopupWindow();
   if (!tray) return;
+  syncCompactWidget();
 
   const tb = tray.getBounds();
   const [w, h] = popupWindow.getSize();
@@ -280,7 +302,12 @@ function showPopup(view: AppView = 'main') {
 }
 
 function sendWidgetStateUpdate(state: AppState) {
-  if (!widgetWindow || widgetWindow.isDestroyed() || !widgetWindow.isVisible()) return;
+  if (!state.settings.compactWidgetEnabled) return;
+  if (!widgetWindow || widgetWindow.isDestroyed()) {
+    syncCompactWidget();
+    return;
+  }
+  if (!widgetWindow.isVisible()) return;
   applyCompactWidgetBounds(state.settings);
   widgetWindow.webContents.send('state:updated', state);
 }
@@ -298,10 +325,7 @@ function syncCompactWidget() {
 }
 
 function hideCompactWidget() {
-  store.set('compactWidgetEnabled', false);
-  syncCompactWidget();
-  stateManager?.applySettingsChange();
-  applyRuntimeSettings();
+  if (widgetWindow && !widgetWindow.isDestroyed()) widgetWindow.hide();
 }
 
 function showCompactWidget() {
@@ -507,12 +531,8 @@ app.whenReady().then(() => {
     if (typeof position?.x !== 'number' || typeof position?.y !== 'number') return;
     if (!Number.isFinite(position.x) || !Number.isFinite(position.y)) return;
     const size = compactWidgetSize(getSettings());
-    widgetWindow.setBounds({
-      x: Math.round(position.x),
-      y: Math.round(position.y),
-      width: size.width,
-      height: size.height,
-    });
+    const next = constrainWidgetPosition({ x: position.x, y: position.y }, size);
+    widgetWindow.setBounds({ ...next, width: size.width, height: size.height });
     persistWidgetPosition(widgetWindow);
   });
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,6 +9,11 @@ import { isDebugInstrumentationEnabled } from './debugInstrumentation';
 
 const DEFAULT_MAIN_SECTION_ORDER = ['planUsage', 'codeOutput', 'sessions', 'activity', 'modelUsage'];
 
+export interface CompactWidgetBounds {
+  x: number;
+  y: number;
+}
+
 export interface AppSettings {
   // 내부용 (UI 미노출, fallback 용도)
   usageLimits: { h5: number; week: number; sonnetWeek: number };
@@ -26,6 +31,8 @@ export interface AppSettings {
   mainSectionOrder: string[];
   hiddenProjects: string[];
   excludedProjects: string[];
+  compactWidgetEnabled: boolean;
+  compactWidgetBounds: CompactWidgetBounds | null;
   theme: 'auto' | 'light' | 'dark';
 }
 
@@ -43,6 +50,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   mainSectionOrder: DEFAULT_MAIN_SECTION_ORDER,
   hiddenProjects: [],
   excludedProjects: [],
+  compactWidgetEnabled: false,
+  compactWidgetBounds: null,
   theme: 'auto',
 };
 
@@ -52,6 +61,11 @@ export function registerIpcHandlers(
   forceRefresh: () => Promise<void>,
   applySettingsChange: () => void,
   getDebugMemSnapshot?: () => Promise<DebugMemSnapshot>,
+  windowActions?: {
+    openDashboard: () => void;
+    openSettings: () => void;
+    hideCompactWidget: () => void;
+  },
 ) {
   ipcMain.handle('state:get', () => getState());
   ipcMain.handle('state:refresh', async () => { await forceRefresh(); return getState(); });
@@ -71,6 +85,9 @@ export function registerIpcHandlers(
 
   ipcMain.handle('notifications:get', () => getHistory());
   ipcMain.handle('notifications:clear', () => { clearHistory(); return []; });
+  ipcMain.handle('window:open-dashboard', () => windowActions?.openDashboard());
+  ipcMain.handle('window:open-settings', () => windowActions?.openSettings());
+  ipcMain.handle('window:hide-compact-widget', () => windowActions?.hideCompactWidget());
   ipcMain.handle('debug-instrumentation-enabled', () => isDebugInstrumentationEnabled());
   ipcMain.handle('debug-mem-snapshot', async () => {
     if (!isDebugInstrumentationEnabled()) return null;

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,6 +7,8 @@ import { AppState, DebugMemSnapshot } from './stateManager';
 import { getHistory, clearHistory } from './notificationHistory';
 import { isDebugInstrumentationEnabled } from './debugInstrumentation';
 
+const DEFAULT_MAIN_SECTION_ORDER = ['planUsage', 'codeOutput', 'sessions', 'activity', 'modelUsage'];
+
 export interface AppSettings {
   // 내부용 (UI 미노출, fallback 용도)
   usageLimits: { h5: number; week: number; sonnetWeek: number };
@@ -15,11 +17,13 @@ export interface AppSettings {
   // 사용자 설정
   alertThresholds: number[]; // [50, 80, 90]
   openAtLogin: boolean;
+  alwaysOnTop: boolean;
   currency: 'USD' | 'KRW';
   usdToKrw: number;
   globalHotkey: string;
   enableAlerts: boolean;
   trayDisplay: 'none' | 'h5pct' | 'tokens' | 'cost';
+  mainSectionOrder: string[];
   hiddenProjects: string[];
   excludedProjects: string[];
   theme: 'auto' | 'light' | 'dark';
@@ -30,11 +34,13 @@ export const DEFAULT_SETTINGS: AppSettings = {
   provider: 'both',
   alertThresholds: [50, 80, 90],
   openAtLogin: false,
+  alwaysOnTop: true,
   currency: 'USD',
   usdToKrw: 1380,
   globalHotkey: 'CommandOrControl+Shift+D',
   enableAlerts: true,
   trayDisplay: 'h5pct',
+  mainSectionOrder: DEFAULT_MAIN_SECTION_ORDER,
   hiddenProjects: [],
   excludedProjects: [],
   theme: 'auto',

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -11,6 +11,11 @@ setupIntegration:     () => ipcRenderer.invoke('integration:setup'),
   getIntegrationStatus: () => ipcRenderer.invoke('integration:status'),
   quit:                 () => ipcRenderer.invoke('app:quit'),
   minimize:             () => ipcRenderer.invoke('window:minimize'),
+  openDashboard:        () => ipcRenderer.invoke('window:open-dashboard'),
+  openSettings:         () => ipcRenderer.invoke('window:open-settings'),
+  hideCompactWidget:    () => ipcRenderer.invoke('window:hide-compact-widget'),
+  getCompactWidgetPosition: () => ipcRenderer.invoke('window:get-compact-widget-position'),
+  setCompactWidgetPosition: (p: { x: number; y: number }) => ipcRenderer.invoke('window:set-compact-widget-position', p),
   isDebugInstrumentationEnabled: () => ipcRenderer.invoke('debug-instrumentation-enabled'),
   getDebugMemSnapshot:  () => ipcRenderer.invoke('debug-mem-snapshot'),
   reportDebugRendererEvent: (payload: Record<string, unknown>) => ipcRenderer.invoke('debug-renderer-event', payload),
@@ -18,6 +23,11 @@ setupIntegration:     () => ipcRenderer.invoke('integration:setup'),
     const handler = (_e: Electron.IpcRendererEvent, state: unknown) => cb(state);
     ipcRenderer.on('state:updated', handler);
     return () => ipcRenderer.removeListener('state:updated', handler);
+  },
+  onNavigate:           (cb: (view: string) => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, view: string) => cb(view);
+    ipcRenderer.on('app:navigate', handler);
+    return () => ipcRenderer.removeListener('app:navigate', handler);
   },
   getResolvedTheme:     () => ipcRenderer.invoke('theme:resolved') as Promise<'light' | 'dark'>,
   onThemeChanged:       (cb: (theme: 'light' | 'dark') => void) => {

--- a/src/main/rateLimitFetcher.ts
+++ b/src/main/rateLimitFetcher.ts
@@ -174,9 +174,9 @@ function asUsageWindow(value: unknown): UsageWindowResponse | null {
   return record;
 }
 
-function scalePct(value: unknown): number {
+function normalizePct(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
-  return value <= 1.0 ? Math.round(value * 100) : Math.round(value);
+  return Math.max(0, Math.min(100, value));
 }
 
 function resetMs(iso: unknown, now: number): ApiResetMs {
@@ -211,13 +211,13 @@ function extraUsageSnapshot(value: unknown): ApiExtraUsage | null {
   const usedCreditsRaw = typeof record.used_credits === 'number' && Number.isFinite(record.used_credits)
     ? record.used_credits
     : (typeof record.usedCredits === 'number' && Number.isFinite(record.usedCredits) ? record.usedCredits : 0);
-  const utilizationValue = scalePct(record.utilization);
+  const utilizationValue = normalizePct(record.utilization);
   const currency = typeof record.currency === 'string' ? record.currency : null;
   return {
     isEnabled: record.is_enabled === true || record.isEnabled === true,
     monthlyLimit: Math.max(0, monthlyLimitRaw),
     usedCredits: Math.max(0, usedCreditsRaw),
-    utilization: Math.max(0, Math.min(100, utilizationValue)),
+    utilization: utilizationValue,
     currency,
   };
 }
@@ -238,9 +238,9 @@ export function normalizeStoredApiUsagePct(value: unknown): StoredApiUsagePct | 
     : undefined;
 
   return {
-    h5Pct: scalePct(record.h5Pct),
-    weekPct: scalePct(record.weekPct),
-    soPct: scalePct(record.soPct),
+    h5Pct: normalizePct(record.h5Pct),
+    weekPct: normalizePct(record.weekPct),
+    soPct: normalizePct(record.soPct),
     h5ResetMs: normalizeResetValue(record.h5ResetMs),
     weekResetMs: normalizeResetValue(record.weekResetMs),
     soResetMs: normalizeResetValue(record.soResetMs),
@@ -401,9 +401,9 @@ export async function fetchApiUsagePct(): Promise<ApiUsageFetchResult> {
       : null;
     const now = Date.now();
     const usage: ApiUsagePct = {
-      h5Pct: scalePct(fiveHour?.utilization),
-      weekPct: scalePct(sevenDay?.utilization),
-      soPct: scalePct(validSonnetWindow?.utilization),
+      h5Pct: normalizePct(fiveHour?.utilization),
+      weekPct: normalizePct(sevenDay?.utilization),
+      soPct: normalizePct(validSonnetWindow?.utilization),
       h5ResetMs: resetMs(fiveHour?.resets_at, now),
       weekResetMs: resetMs(sevenDay?.resets_at, now),
       soResetMs: resetMs(validSonnetWindow?.resets_at, now),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import HelpView from './views/HelpView';
 import RenderErrorBoundary from './components/RenderErrorBoundary';
 import { getTheme, applyThemeCssVars, Theme } from './theme';
 import { ThemeProvider } from './ThemeContext';
+import { DEFAULT_MAIN_SECTION_ORDER, normalizeMainSectionOrder } from './mainSections';
 
 type View = 'main' | 'settings' | 'notifications' | 'help';
 
@@ -44,9 +45,11 @@ const DEFAULT_STATE: AppState = {
     usageLimits: { h5:100, week:2000, sonnetWeek:100_000_000 },
     provider: 'both',
     alertThresholds: [50,80,90], openAtLogin: false,
+    alwaysOnTop: true,
     currency: 'USD', usdToKrw: 1380,
     globalHotkey: 'CommandOrControl+Shift+D', enableAlerts: true,
     trayDisplay: 'h5pct', theme: 'auto',
+    mainSectionOrder: DEFAULT_MAIN_SECTION_ORDER,
     hiddenProjects: [], excludedProjects: [],
   },
   autoLimits: null,
@@ -183,6 +186,7 @@ function normalizeState(next: AppState): AppState {
       ...DEFAULT_STATE.settings,
       ...next.settings,
       alertThresholds: arrayOrEmpty(next.settings?.alertThresholds),
+      mainSectionOrder: normalizeMainSectionOrder(next.settings?.mainSectionOrder),
       hiddenProjects: arrayOrEmpty(next.settings?.hiddenProjects),
       excludedProjects: arrayOrEmpty(next.settings?.excludedProjects),
     },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import MainView from './views/MainView';
 import SettingsView from './views/SettingsView';
 import NotificationsView from './views/NotificationsView';
 import HelpView from './views/HelpView';
+import CompactWidgetView from './views/CompactWidgetView';
 import RenderErrorBoundary from './components/RenderErrorBoundary';
 import { getTheme, applyThemeCssVars, Theme } from './theme';
 import { ThemeProvider } from './ThemeContext';
@@ -51,6 +52,7 @@ const DEFAULT_STATE: AppState = {
     trayDisplay: 'h5pct', theme: 'auto',
     mainSectionOrder: DEFAULT_MAIN_SECTION_ORDER,
     hiddenProjects: [], excludedProjects: [],
+    compactWidgetEnabled: false, compactWidgetBounds: null,
   },
   autoLimits: null,
   codexAccount: { serviceTier: null },
@@ -189,6 +191,12 @@ function normalizeState(next: AppState): AppState {
       mainSectionOrder: normalizeMainSectionOrder(next.settings?.mainSectionOrder),
       hiddenProjects: arrayOrEmpty(next.settings?.hiddenProjects),
       excludedProjects: arrayOrEmpty(next.settings?.excludedProjects),
+      compactWidgetEnabled: next.settings?.compactWidgetEnabled === true,
+      compactWidgetBounds: next.settings?.compactWidgetBounds
+        && typeof next.settings.compactWidgetBounds.x === 'number'
+        && typeof next.settings.compactWidgetBounds.y === 'number'
+        ? next.settings.compactWidgetBounds
+        : null,
     },
     historyWarmupStartsAt: typeof next.historyWarmupStartsAt === 'number' && Number.isFinite(next.historyWarmupStartsAt)
       ? next.historyWarmupStartsAt
@@ -396,6 +404,7 @@ function BootFallback({
 }
 
 export default function App() {
+  const isWidget = useMemo(() => new URLSearchParams(window.location.search).get('view') === 'widget', []);
   const [state, setState] = useState<AppState>(DEFAULT_STATE);
   const [view, setView] = useState<View>('main');
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('dark');
@@ -471,6 +480,15 @@ export default function App() {
     return cleanup;
   }, [refresh, applyState]);
 
+  useEffect(() => {
+    if (isWidget) return;
+    return window.wmt.onNavigate(nextView => {
+      if (nextView === 'main' || nextView === 'settings' || nextView === 'notifications' || nextView === 'help') {
+        setView(nextView);
+      }
+    });
+  }, [isWidget]);
+
   useEffect(() => () => {
     if (scrollTimerRef.current !== null) window.clearTimeout(scrollTimerRef.current);
   }, []);
@@ -537,6 +555,16 @@ export default function App() {
   useEffect(() => { applyThemeCssVars(theme); }, [theme]);
 
   const bgStyle: React.CSSProperties = { background: theme.bg, height: '100vh', color: theme.text };
+
+  if (isWidget) {
+    return (
+      <ThemeProvider value={theme}>
+        <RenderErrorBoundary label="Compact Widget" fill>
+          <CompactWidgetView state={state} onRefresh={retryStartup} />
+        </RenderErrorBoundary>
+      </ThemeProvider>
+    );
+  }
 
   if (bootFallbackVisible && !state.initialRefreshComplete && view === 'main') {
     return (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -210,6 +210,15 @@ function normalizeState(next: AppState): AppState {
   };
 }
 
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName;
+  return tagName === 'INPUT'
+    || tagName === 'TEXTAREA'
+    || tagName === 'SELECT'
+    || target.isContentEditable;
+}
+
 function sameNumberRecord(a: Record<string, number> | null | undefined, b: Record<string, number> | null | undefined): boolean {
   if (a === b) return true;
   if (!a || !b) return !a && !b;
@@ -465,6 +474,21 @@ export default function App() {
   useEffect(() => () => {
     if (scrollTimerRef.current !== null) window.clearTimeout(scrollTimerRef.current);
   }, []);
+
+  useEffect(() => {
+    if (view !== 'main') return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+      if (isEditableTarget(event.target)) return;
+      event.preventDefault();
+      window.wmt.minimize().catch(() => {});
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [view]);
 
   // 시스템 테마 감지: 초기 resolve + 실시간 변경 리스너
   useEffect(() => {

--- a/src/renderer/components/ActivityBreakdown.tsx
+++ b/src/renderer/components/ActivityBreakdown.tsx
@@ -57,7 +57,7 @@ function ActivityBreakdown({ session }: Props) {
         <span style={{ fontSize: 15, fontWeight: 800, color: C.text, fontFamily: C.fontMono, lineHeight: 1 }}>
           {fmtValue(total)}
         </span>
-        <span style={{ fontSize: 9, color: C.textMuted }}>{totalLabel}</span>
+        <span style={{ fontSize: 10, color: C.textMuted }}>{totalLabel}</span>
       </div>
 
       {/* 스택 바 */}
@@ -82,12 +82,12 @@ function ActivityBreakdown({ session }: Props) {
           return (
             <div key={cat.key}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 2 }}>
-                <span style={{ fontSize: 10, width: 14, textAlign: 'center', flexShrink: 0 }}>{cat.icon}</span>
-                <span style={{ fontSize: 10, color: C.textDim, flex: 1 }}>{cat.label}</span>
-                <span style={{ fontSize: 9, fontFamily: C.fontMono, color: C.textMuted, width: 42, textAlign: 'right', flexShrink: 0 }}>
+                <span style={{ fontSize: 11, width: 14, textAlign: 'center', flexShrink: 0 }}>{cat.icon}</span>
+                <span style={{ fontSize: 11, color: C.textDim, flex: 1 }}>{cat.label}</span>
+                <span style={{ fontSize: 10, fontFamily: C.fontMono, color: C.textMuted, width: 42, textAlign: 'right', flexShrink: 0 }}>
                   {fmtValue(tokens)}
                 </span>
-                <span style={{ fontSize: 9, fontFamily: C.fontMono, color: C.textMuted, width: 26, textAlign: 'right', flexShrink: 0 }}>
+                <span style={{ fontSize: 10, fontFamily: C.fontMono, color: C.textMuted, width: 26, textAlign: 'right', flexShrink: 0 }}>
                   {Math.round(pct)}%
                 </span>
               </div>

--- a/src/renderer/components/ActivityChart.tsx
+++ b/src/renderer/components/ActivityChart.tsx
@@ -116,7 +116,7 @@ function Heatmap7({ data }: { data: HourlyBucket[] }) {
         <div style={{
           position: 'absolute', left: Math.min(tooltip.x + 4, 220), top: Math.max(tooltip.y - 32, 0),
           background: C.bgCard, border: `1px solid ${C.border}`, borderRadius: 4,
-          padding: '2px 6px', fontSize: 9, fontFamily: C.fontMono, pointerEvents: 'none', whiteSpace: 'nowrap',
+          padding: '2px 6px', fontSize: 10, fontFamily: C.fontMono, pointerEvents: 'none', whiteSpace: 'nowrap',
         }}>
           <span style={{ color: C.textMuted }}>{tooltip.day} {tooltip.hour}h </span>
           <span style={{ color: tooltip.tokens > 0 ? C.text : C.textMuted, fontWeight: 600 }}>
@@ -262,7 +262,7 @@ function Heatmap90({ data }: { data: HourlyBucket[] }) {
         <div style={{
           position: 'absolute', left: Math.min(tooltip.x + 4, 220), top: Math.max(tooltip.y - 32, 0),
           background: C.bgCard, border: `1px solid ${C.border}`,
-          borderRadius: 4, padding: '3px 7px', fontSize: 10, pointerEvents: 'none', zIndex: 10,
+          borderRadius: 4, padding: '3px 7px', fontSize: 11, pointerEvents: 'none', zIndex: 10,
         }}>
           <span style={{ color: C.textMuted }}>{tooltip.date} </span>
           <span style={{ color: tooltip.tokens > 0 ? C.text : C.textMuted, fontWeight: 600 }}>
@@ -360,7 +360,7 @@ function HourlyDistribution({ data }: { data: HourlyBucket[] }) {
         <div style={{
           position: 'absolute', top: 6, left: Math.min(tooltip.x, 220),
           background: C.bgCard, border: `1px solid ${C.border}`,
-          borderRadius: 4, padding: '3px 7px', fontSize: 10, pointerEvents: 'none', zIndex: 10,
+          borderRadius: 4, padding: '3px 7px', fontSize: 11, pointerEvents: 'none', zIndex: 10,
         }}>
           <span style={{ color: C.textMuted }}>{tooltip.hour}h </span>
           <span style={{ color: C.text, fontWeight: 600 }}>{fmtTokens(tooltip.tokens)} tok</span>
@@ -417,12 +417,12 @@ function WeeklyGrowthChart({ data }: { data: WeeklyTotal[] }) {
         return (
           <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 7 }}>
             <div style={{
-              width: 52, fontSize: 9, fontWeight: isCurrent ? 700 : 400,
+              width: 52, fontSize: 10, fontWeight: isCurrent ? 700 : 400,
               color: isCurrent ? C.accent : C.textMuted, textAlign: 'right', flexShrink: 0,
               letterSpacing: -0.2,
             }}>
               {label}
-              <div style={{ fontSize: 8, color: C.textMuted, fontWeight: 400 }}>{weekRange(i)}</div>
+              <div style={{ fontSize: 9, color: C.textMuted, fontWeight: 400 }}>{weekRange(i)}</div>
             </div>
 
             <div style={{ flex: 1, position: 'relative', height: 14 }}>
@@ -436,7 +436,7 @@ function WeeklyGrowthChart({ data }: { data: WeeklyTotal[] }) {
             </div>
 
             <div style={{
-              width: 62, fontSize: 10, fontWeight: isCurrent ? 700 : 400,
+              width: 62, fontSize: 11, fontWeight: isCurrent ? 700 : 400,
               color: isCurrent ? C.text : C.textDim, textAlign: 'right', flexShrink: 0,
             }}>
               {fmtTokens(entry.tokens)}
@@ -448,7 +448,7 @@ function WeeklyGrowthChart({ data }: { data: WeeklyTotal[] }) {
       <div style={{
         marginTop: 4, paddingTop: 5, borderTop: `1px solid ${C.border}`,
         display: 'flex', justifyContent: 'space-between',
-        fontSize: 9, color: C.textMuted,
+        fontSize: 10, color: C.textMuted,
       }}>
         <span>
           <span style={{ color: C.textDim }}>4-week total </span>
@@ -480,7 +480,7 @@ export function TODPanel({ data, currency, usdToKrw }: { data: TimeOfDayBucket[]
 
   if (data.every(b => b.tokens === 0)) {
     return (
-      <div style={{ height: 80, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, color: C.textMuted }}>
+      <div style={{ height: 80, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, color: C.textMuted }}>
         No data
       </div>
     );
@@ -503,11 +503,11 @@ export function TODPanel({ data, currency, usdToKrw }: { data: TimeOfDayBucket[]
           <div key={bucket.period} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
             <span style={{ fontSize: 13, width: 18, textAlign: 'center' }}>{info.icon}</span>
             <span style={{
-              fontSize: 10, width: 52, flexShrink: 0, fontFamily: C.fontMono,
+              fontSize: 11, width: 52, flexShrink: 0, fontFamily: C.fontMono,
               color: isPeak ? info.color : C.textDim,
               fontWeight: isPeak ? 600 : 400,
             }}>{info.name}</span>
-            <span style={{ fontSize: 8, width: 34, flexShrink: 0, color: C.textMuted, fontFamily: C.fontMono }}>{info.time}</span>
+            <span style={{ fontSize: 9, width: 34, flexShrink: 0, color: C.textMuted, fontFamily: C.fontMono }}>{info.time}</span>
             <div style={{ flex: 1, height: 8, background: C.bgRow, borderRadius: 4, overflow: 'hidden' }}>
               <div style={{
                 width: `${Math.max(pct * 100, bucket.tokens > 0 ? 3 : 0)}%`,
@@ -516,7 +516,7 @@ export function TODPanel({ data, currency, usdToKrw }: { data: TimeOfDayBucket[]
               }} />
             </div>
             <span style={{
-              width: 48, fontSize: 10, textAlign: 'right', flexShrink: 0,
+              width: 48, fontSize: 11, textAlign: 'right', flexShrink: 0,
               fontFamily: C.fontMono,
               color: isPeak ? info.color : C.textDim,
               fontWeight: isPeak ? 700 : 400,
@@ -539,12 +539,12 @@ export function TODPanel({ data, currency, usdToKrw }: { data: TimeOfDayBucket[]
           }}>
             {/* Peak 헤더 + 30d total */}
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
-              <span style={{ fontSize: 9, color: C.textDim, fontFamily: C.fontMono }}>
+              <span style={{ fontSize: 10, color: C.textDim, fontFamily: C.fontMono }}>
                 🔥 Peak: <strong style={{ color: peakColor }}>
                   {peakInfo?.name ?? peakPeriod.label}
                 </strong>
               </span>
-              <span style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono }}>
+              <span style={{ fontSize: 10, color: C.textMuted, fontFamily: C.fontMono }}>
                 30d · {fmtCost(totalCost, currency, usdToKrw)} total
               </span>
             </div>
@@ -563,9 +563,9 @@ export function TODPanel({ data, currency, usdToKrw }: { data: TimeOfDayBucket[]
                   padding: '6px 8px', textAlign: 'center',
                   borderRight: i < 2 ? `1px solid ${C.border}` : 'none',
                 }}>
-                  <div style={{ fontSize: 8, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 0.3, marginBottom: 2 }}>{item.label}</div>
+                  <div style={{ fontSize: 9, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 0.3, marginBottom: 2 }}>{item.label}</div>
                   <div style={{ fontSize: 13, fontWeight: 700, color: peakColor, fontFamily: C.fontMono, lineHeight: 1.2 }}>{item.value}</div>
-                  <div style={{ fontSize: 8, color: C.textMuted, marginTop: 1 }}>{item.sub}</div>
+                  <div style={{ fontSize: 9, color: C.textMuted, marginTop: 1 }}>{item.sub}</div>
                 </div>
               ))}
             </div>
@@ -581,11 +581,11 @@ function ColorLegend() {
   const C = useTheme();
   return (
     <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 4, marginTop: 3 }}>
-      <span style={{ fontSize: 9, color: C.textMuted }}>less</span>
+      <span style={{ fontSize: 10, color: C.textMuted }}>less</span>
       {[0, 0.25, 0.5, 0.75, 1].map(i => (
         <div key={i} style={{ width: 7, height: 7, borderRadius: 1, background: blueIntensity(i) }} />
       ))}
-      <span style={{ fontSize: 9, color: C.textMuted }}>more</span>
+      <span style={{ fontSize: 10, color: C.textMuted }}>more</span>
     </div>
   );
 }
@@ -609,8 +609,8 @@ function ActivityChart({ heatmap, heatmap30, heatmap90, weeklyTimeline, todBucke
       {/* 헤더: 제목 + 탭 */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 10px 5px 12px', background: C.bgRow, borderBottom: `1px solid ${C.border}` }}>
         <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-          <span style={{ fontSize: 10, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Activity</span>
-          <span style={{ fontSize: 9, color: C.textDim, fontFamily: C.fontMono, background: C.bgRow, padding: '2px 6px', borderRadius: 3, border: `1px solid ${C.border}` }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Activity</span>
+          <span style={{ fontSize: 10, color: C.textDim, fontFamily: C.fontMono, background: C.bgRow, padding: '2px 6px', borderRadius: 3, border: `1px solid ${C.border}` }}>
             {LOCAL_TIME_ZONE_LABEL}
           </span>
         </span>
@@ -620,7 +620,7 @@ function ActivityChart({ heatmap, heatmap30, heatmap90, weeklyTimeline, todBucke
             const isActive = tab === t;
             return (
               <button key={t} onClick={() => setTab(t)} style={{
-                padding: '4px 8px', fontSize: 9, borderRadius: 3, cursor: 'pointer',
+                padding: '4px 8px', fontSize: 10, borderRadius: 3, cursor: 'pointer',
                 fontFamily: "'JetBrains Mono', monospace",
                 border: isActive && isRhythm ? '1px solid rgba(251,191,36,0.2)' :
                         isActive ? `1px solid rgba(13,148,136,0.15)` : '1px solid transparent',
@@ -647,20 +647,20 @@ function ActivityChart({ heatmap, heatmap30, heatmap90, weeklyTimeline, todBucke
         )}
         {tab === '5mo' && (
           <>
-            <div style={{ fontSize: 9, color: C.textMuted, marginBottom: 3 }}>5mo activity</div>
+            <div style={{ fontSize: 10, color: C.textMuted, marginBottom: 3 }}>5mo activity</div>
             <Heatmap90 data={heatmap90} />
             <ColorLegend />
           </>
         )}
         {tab === 'Hourly' && (
           <>
-            <div style={{ fontSize: 9, color: C.textMuted, marginBottom: 3 }}>Hourly (30d)</div>
+            <div style={{ fontSize: 10, color: C.textMuted, marginBottom: 3 }}>Hourly (30d)</div>
             <HourlyDistribution data={heatmap30} />
           </>
         )}
         {tab === 'Weekly' && (
           <>
-            <div style={{ fontSize: 9, color: C.textMuted, marginBottom: 3 }}>Weekly (4w)</div>
+            <div style={{ fontSize: 10, color: C.textMuted, marginBottom: 3 }}>Weekly (4w)</div>
             <WeeklyGrowthChart data={weeklyTimeline} />
           </>
         )}

--- a/src/renderer/components/CodeOutputCard.tsx
+++ b/src/renderer/components/CodeOutputCard.tsx
@@ -51,15 +51,15 @@ function CodeOutputCard({ stats, loading = false, todayCost, allTimeCost, curren
     <div style={{ margin: '10px 8px 0', background: C.bgCard, borderRadius: 10, overflow: 'hidden', border: `1px solid ${C.border}` }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 14px 5px 12px', background: C.bgRow, borderBottom: `1px solid ${C.border}` }}>
         <div style={{ minWidth: 0, marginRight: 8 }}>
-          <div style={{ fontSize: 10, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Code Output</div>
-          <div style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          <div style={{ fontSize: 11, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Code Output</div>
+          <div style={{ fontSize: 10, color: C.textMuted, fontFamily: C.fontMono, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
             {stats.scopeLabel}
           </div>
         </div>
         <div style={{ display: 'flex', gap: 2 }}>
           {PERIODS.map(p => (
             <button key={p} onClick={() => setPeriod(p)} style={{
-              padding: '2px 6px', fontSize: 9, borderRadius: 3, cursor: 'pointer',
+              padding: '2px 6px', fontSize: 10, borderRadius: 3, cursor: 'pointer',
               fontFamily: "'JetBrains Mono', monospace",
               border: period === p ? '1px solid rgba(13,148,136,0.15)' : '1px solid transparent',
               background: period === p ? C.accent + '22' : 'none',
@@ -92,7 +92,7 @@ function CodeOutputCard({ stats, loading = false, todayCost, allTimeCost, curren
               padding: '6px 14px',
               borderTop: `1px solid ${C.border}`,
             }}>
-              <span style={{ fontSize: 9, color: C.textDim, fontFamily: C.fontMono }}>
+              <span style={{ fontSize: 10, color: C.textDim, fontFamily: C.fontMono }}>
                 {data.commits} commit{data.commits > 1 ? 's' : ''} - {netLines >= 0 ? '+' : ''}{netLines} net lines
                 {perLine ? ` - ${fmtCost(perLine, currency, usdToKrw)}/100 added` : ''}
               </span>
@@ -109,13 +109,13 @@ export default React.memo(CodeOutputCard);
 function CodeOutputLoading({ C }: { C: ReturnType<typeof useTheme> }) {
   return (
     <div style={{ padding: '18px 14px 16px', borderTop: `1px solid ${C.border}`, color: C.textMuted }}>
-      <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.6, fontWeight: 700, marginBottom: 8 }}>
+      <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.6, fontWeight: 700, marginBottom: 8 }}>
         Scanning git history
       </div>
       <div style={{ height: 4, background: C.bgRow, borderRadius: 999, overflow: 'hidden' }}>
         <div style={{ width: '44%', height: '100%', background: C.accent, opacity: 0.7, borderRadius: 999 }} />
       </div>
-      <div style={{ marginTop: 8, fontSize: 9, fontFamily: C.fontMono }}>Code Output will appear after local repo stats finish.</div>
+      <div style={{ marginTop: 8, fontSize: 10, fontFamily: C.fontMono }}>Code Output will appear after local repo stats finish.</div>
     </div>
   );
 }
@@ -244,13 +244,13 @@ function OutputGrowth({
   return (
     <div style={{ borderTop: `1px solid ${C.border}`, padding: '6px 12px 5px' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 2 }}>
-        <span style={{ fontSize: 9, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.6, fontWeight: 700 }}>Output Growth</span>
-        <span style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono }}>
+        <span style={{ fontSize: 10, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.6, fontWeight: 700 }}>Output Growth</span>
+        <span style={{ fontSize: 10, color: C.textMuted, fontFamily: C.fontMono }}>
           <span style={{ color: progressColor, fontWeight: 700 }}>{fmtSigned(totalNet)}</span> total net
           <span> - {total.commits} commits</span>
         </span>
       </div>
-      <div style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono, marginBottom: 1 }}>
+      <div style={{ fontSize: 10, color: C.textMuted, fontFamily: C.fontMono, marginBottom: 1 }}>
         Last 7 days on all-time baseline
       </div>
       <div style={{ position: 'relative' }}>
@@ -273,7 +273,7 @@ function OutputGrowth({
             padding: '5px 7px',
             boxShadow: '0 8px 20px rgba(0,0,0,0.25)',
             fontFamily: C.fontMono,
-            fontSize: 9,
+            fontSize: 10,
             color: C.text,
             lineHeight: 1.35,
             zIndex: 2,
@@ -330,10 +330,10 @@ function KPI({ label, value, sub, subColor, color, C, borderRight }: {
       borderRight: borderRight ? `1px solid ${C.border}` : 'none',
       textAlign: 'center',
     }}>
-      <div style={{ fontSize: 8, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 9, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 }}>{label}</div>
       <div style={{ fontSize: 18, fontWeight: 800, color, fontFamily: C.fontMono, lineHeight: 1 }}>{value}</div>
       {sub && (
-        <div style={{ fontSize: 9, color: subColor ?? C.textMuted, marginTop: 2 }}>{sub}</div>
+        <div style={{ fontSize: 10, color: subColor ?? C.textMuted, marginTop: 2 }}>{sub}</div>
       )}
     </div>
   );

--- a/src/renderer/components/ExtraUsageCard.tsx
+++ b/src/renderer/components/ExtraUsageCard.tsx
@@ -45,7 +45,7 @@ function ExtraUsageCard({ extraUsage, variant = 'row' }: Props) {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 5 }}>
         <span style={{ fontSize: isBanner ? 12 : 11, color: isHigh ? C.barRed : C.textMuted, fontWeight: isHigh ? 800 : 400 }}>{title}</span>
         <div style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>
-          <span style={{ fontSize: 10, color: C.textMuted, fontFamily: C.fontMono }}>${usedUSD} / ${limitUSD}</span>
+          <span style={{ fontSize: 11, color: C.textMuted, fontFamily: C.fontMono }}>${usedUSD} / ${limitUSD}</span>
           <span style={{ fontSize: 12, fontWeight: 700, color: barPct >= 99 ? C.barRed : barColor, fontFamily: C.fontMono }}>{Math.round(barPct)}%</span>
         </div>
       </div>
@@ -59,7 +59,7 @@ function ExtraUsageCard({ extraUsage, variant = 'row' }: Props) {
           }} />
         </div>
         {resetStr && (
-          <span style={{ fontSize: 9, color: C.textMuted, flexShrink: 0 }}>{resetStr}</span>
+          <span style={{ fontSize: 10, color: C.textMuted, flexShrink: 0 }}>{resetStr}</span>
         )}
       </div>
     </div>

--- a/src/renderer/components/ModelBreakdown.tsx
+++ b/src/renderer/components/ModelBreakdown.tsx
@@ -29,8 +29,8 @@ function ModelBreakdown({ models, currency, usdToKrw }: { models: ModelUsage[]; 
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '6px 14px 5px 12px', background: C.bgRow, borderBottom: `1px solid ${C.border}` }}>
-        <span style={{ fontSize: 10, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Model Usage</span>
-        <span style={{ fontSize: 9, color: C.textMuted }}>Top 4 - All time</span>
+        <span style={{ fontSize: 11, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Model Usage</span>
+        <span style={{ fontSize: 10, color: C.textMuted }}>Top 4 - All time</span>
       </div>
       <div style={{ padding: '6px 14px 8px' }}>
         {models.slice(0, 4).map(m => {
@@ -40,7 +40,7 @@ function ModelBreakdown({ models, currency, usdToKrw }: { models: ModelUsage[]; 
             <div key={`${m.provider}:${m.model}`} style={{ marginBottom: 6 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 2 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0, flex: 1, marginRight: 8 }}>
-                  <span style={{ fontSize: 8, color: C.textMuted, background: C.bgRow, border: `1px solid ${C.border}`, borderRadius: 4, padding: '1px 4px', flexShrink: 0 }}>
+                  <span style={{ fontSize: 9, color: C.textMuted, background: C.bgRow, border: `1px solid ${C.border}`, borderRadius: 4, padding: '1px 4px', flexShrink: 0 }}>
                     {provider}
                   </span>
                   <span title={m.model} style={{ fontSize: 11, color, fontWeight: 600, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
@@ -48,7 +48,7 @@ function ModelBreakdown({ models, currency, usdToKrw }: { models: ModelUsage[]; 
                   </span>
                 </div>
                 <div style={{ display: 'flex', gap: 8 }}>
-                  <span style={{ fontSize: 10, color: C.textMuted, fontFamily: C.fontMono }}>{fmtTokens(m.tokens)}</span>
+                  <span style={{ fontSize: 11, color: C.textMuted, fontFamily: C.fontMono }}>{fmtTokens(m.tokens)}</span>
                   <span style={{ fontSize: 11, color: C.textDim, fontFamily: C.fontMono }}>{fmtCost(m.costUSD, currency, usdToKrw)}</span>
                 </div>
               </div>

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -73,23 +73,23 @@ function SessionRow({ session, expanded, onToggle }: {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 }}>
           {session.modelName && (
-            <span title={session.modelName} style={{ fontSize: 8, background: mc + '18', color: mc, border: `1px solid ${mc}33`, borderRadius: 3, padding: '1px 5px', fontWeight: 700, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span title={session.modelName} style={{ fontSize: 9, background: mc + '18', color: mc, border: `1px solid ${mc}33`, borderRadius: 3, padding: '1px 5px', fontWeight: 700, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {session.modelName}
             </span>
           )}
-          <span style={{ fontSize: 8, background: session.provider === 'codex' ? C.output + '16' : C.accentDim, color: session.provider === 'codex' ? C.output : C.textMuted, border: `1px solid ${C.border}`, borderRadius: 3, padding: '1px 5px', fontWeight: 700 }}>
+          <span style={{ fontSize: 9, background: session.provider === 'codex' ? C.output + '16' : C.accentDim, color: session.provider === 'codex' ? C.output : C.textMuted, border: `1px solid ${C.border}`, borderRadius: 3, padding: '1px 5px', fontWeight: 700 }}>
             {session.provider === 'codex' ? 'Codex' : 'Claude'}
           </span>
-          <span title={session.source} style={{ fontSize: 10, color: C.textMuted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{session.source}</span>
+          <span title={session.source} style={{ fontSize: 11, color: C.textMuted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{session.source}</span>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
           {showCtx && (
-            <span style={{ fontSize: 8, color: C.textMuted, fontFamily: C.fontMono }}>{Math.round(ctxPct)}% ctx</span>
+            <span style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono }}>{Math.round(ctxPct)}% ctx</span>
           )}
-          <span style={{ fontSize: 8, background: 'rgba(255,255,255,0.04)', color: C.textMuted, borderRadius: 3, padding: '1px 5px', border: `1px solid rgba(255,255,255,0.04)` }}>
+          <span style={{ fontSize: 9, background: 'rgba(255,255,255,0.04)', color: C.textMuted, borderRadius: 3, padding: '1px 5px', border: `1px solid rgba(255,255,255,0.04)` }}>
             {stateLabel(session.state)}
           </span>
-          <span style={{ fontSize: 8, color: C.textMuted, fontFamily: C.fontMono }}>{fmtRelative(session.lastModified)}</span>
+          <span style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono }}>{fmtRelative(session.lastModified)}</span>
         </div>
       </div>
     );
@@ -113,14 +113,14 @@ function SessionRow({ session, expanded, onToggle }: {
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 }}>
             {session.modelName && (
-              <span title={session.modelName} style={{ fontSize: 8, background: mc + '18', color: mc, border: `1px solid ${mc}33`, borderRadius: 3, padding: '1px 5px', fontWeight: 700, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              <span title={session.modelName} style={{ fontSize: 9, background: mc + '18', color: mc, border: `1px solid ${mc}33`, borderRadius: 3, padding: '1px 5px', fontWeight: 700, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {session.modelName}
               </span>
             )}
-            <span style={{ fontSize: 8, background: session.provider === 'codex' ? C.output + '16' : C.accentDim, color: session.provider === 'codex' ? C.output : C.textMuted, border: `1px solid ${C.border}`, borderRadius: 3, padding: '1px 5px', fontWeight: 700 }}>
+            <span style={{ fontSize: 9, background: session.provider === 'codex' ? C.output + '16' : C.accentDim, color: session.provider === 'codex' ? C.output : C.textMuted, border: `1px solid ${C.border}`, borderRadius: 3, padding: '1px 5px', fontWeight: 700 }}>
               {session.provider === 'codex' ? 'Codex' : 'Claude'}
             </span>
-            <span title={session.source} style={{ fontSize: 10, color: C.textMuted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{session.source}</span>
+            <span title={session.source} style={{ fontSize: 11, color: C.textMuted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{session.source}</span>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 5, flexShrink: 0 }}>
             {hasBreakdown && (
@@ -138,7 +138,7 @@ function SessionRow({ session, expanded, onToggle }: {
                   color: isExpanded ? C.accent : C.textDim,
                   cursor: 'pointer',
                   padding: '0 6px',
-                  fontSize: 8,
+                  fontSize: 9,
                   fontFamily: C.fontMono,
                   fontWeight: 700,
                 }}
@@ -152,7 +152,7 @@ function SessionRow({ session, expanded, onToggle }: {
               </button>
             )}
             <span style={{
-              fontSize: 8, padding: '1px 5px', borderRadius: 3, fontWeight: 600,
+              fontSize: 9, padding: '1px 5px', borderRadius: 3, fontWeight: 600,
               fontFamily: C.fontMono,
               background: session.state === 'active' ? C.active + '1a' :
                           session.state === 'waiting' ? C.waiting + '1a' : 'rgba(255,255,255,0.04)',
@@ -161,16 +161,16 @@ function SessionRow({ session, expanded, onToggle }: {
             }}>
               {stateLabel(session.state)}
             </span>
-            <span style={{ fontSize: 8, color: C.textMuted, fontFamily: C.fontMono }}>{fmtRelative(session.lastModified)}</span>
+            <span style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono }}>{fmtRelative(session.lastModified)}</span>
           </div>
         </div>
 
         {showCtx && (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginTop: 4 }}>
-            <span style={{ fontSize: 9, color: ctxPct >= 95 ? C.barRed : C.textMuted, fontFamily: C.fontMono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span style={{ fontSize: 10, color: ctxPct >= 95 ? C.barRed : C.textMuted, fontFamily: C.fontMono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               Context {Math.round(ctxPct)}%
             </span>
-            <span style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span style={{ fontSize: 10, color: C.textMuted, fontFamily: C.fontMono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {ctxLabel}
             </span>
           </div>
@@ -204,7 +204,7 @@ function SessionRow({ session, expanded, onToggle }: {
             <div style={{ display: 'flex', gap: 3, marginTop: 3, flexWrap: 'wrap', width: '100%' }}>
               {displayEntries.map(([name, count]) => (
                 <span key={name} style={{
-                  fontSize: 10, fontFamily: C.fontMono, padding: '2px 5px', borderRadius: 3,
+                  fontSize: 11, fontFamily: C.fontMono, padding: '2px 5px', borderRadius: 3,
                   background: 'rgba(255,255,255,0.04)', color: C.textMuted,
                   border: '1px solid rgba(255,255,255,0.05)',
                   maxWidth: 132, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
@@ -214,7 +214,7 @@ function SessionRow({ session, expanded, onToggle }: {
               ))}
               {hiddenToolCount > 0 && (
                 <span style={{
-                  fontSize: 10, fontFamily: C.fontMono, padding: '2px 5px', borderRadius: 3,
+                  fontSize: 11, fontFamily: C.fontMono, padding: '2px 5px', borderRadius: 3,
                   background: 'rgba(255,255,255,0.03)', color: C.textMuted,
                   border: '1px solid rgba(255,255,255,0.04)',
                 }}>

--- a/src/renderer/components/TokenStatsCard.tsx
+++ b/src/renderer/components/TokenStatsCard.tsx
@@ -25,6 +25,26 @@ function pctBarColor(pct: number, C: Theme): string {
   return C.accent;
 }
 
+function formatUsagePct(pct: number): string {
+  if (pct <= 0) return '0%';
+  if (pct < 1) return '<1%';
+  if (pct < 10) return `${Math.round(pct * 10) / 10}%`;
+  return `${Math.round(pct)}%`;
+}
+
+function windowDurationMs(period: string): number | null {
+  const normalized = period.trim().toLowerCase();
+  if (normalized === '5h') return 5 * 60 * 60 * 1000;
+  if (normalized === '1w') return 7 * 24 * 60 * 60 * 1000;
+  return null;
+}
+
+function timeGonePct(period: string, resetMs: number | null | undefined): number | null {
+  const durationMs = windowDurationMs(period);
+  if (!durationMs || resetMs == null || resetMs < 0 || resetMs > durationMs) return null;
+  return Math.max(0, Math.min(100, ((durationMs - resetMs) / durationMs) * 100));
+}
+
 interface Props {
   provider: string;
   period: string;
@@ -48,7 +68,7 @@ function TokenDotRow({ label, value, color }: { label: string; value: number; co
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, marginRight: 10 }}>
       <span style={{ width: 6, height: 6, borderRadius: '50%', background: color, flexShrink: 0 }} />
-      <span style={{ fontSize: 9 }}>{label} {fmtTokens(value)}</span>
+      <span style={{ fontSize: 10 }}>{label} {fmtTokens(value)}</span>
     </span>
   );
 }
@@ -67,7 +87,7 @@ function TokenStatsCard({
   const costColor = stats.costUSD > 5 ? C.barRed : stats.costUSD > 2 ? C.barYellow : C.textDim;
 
   const showLimitBar = limitPct != null;
-  const barPct = Math.min(100, limitPct ?? 0);
+  const barPct = Math.max(0, Math.min(100, limitPct ?? 0));
   const barColor = pctBarColor(barPct, C);
 
   let resetStr = '';
@@ -89,10 +109,11 @@ function TokenStatsCard({
   const cacheTitle = cacheBadgeTitle(cacheMetricMode);
   const showSavings = stats.cacheSavingsUSD > 0.005;
   const showEta = burnRate && burnRate.h5EtaMs !== null && resetMs != null && burnRate.h5EtaMs < resetMs;
+  const timeGone = timeGonePct(period, resetMs);
   const sourceChip = limitSourceLabel ? (
     <span
       title={limitSourceLabel}
-      style={{ fontSize: 8, fontWeight: 700, padding: '1px 4px', borderRadius: 4, background: C.bgRow, color: C.textMuted, border: `1px solid ${C.border}`, maxWidth: 92, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+      style={{ fontSize: 9, fontWeight: 700, padding: '1px 4px', borderRadius: 4, background: C.bgRow, color: C.textMuted, border: `1px solid ${C.border}`, maxWidth: 92, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
     >
       {limitSourceLabel}
     </span>
@@ -109,7 +130,7 @@ function TokenStatsCard({
       }}>
         {/* 제공자 + 등급 */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-          <span style={{ fontSize: 9, fontWeight: 700, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 1, minWidth: 0 }}>
+          <span style={{ fontSize: 10, fontWeight: 700, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 1, minWidth: 0 }}>
             {provider} {period}
             {!limitSourceLabel && apiConnected === false && limitPct != null && limitPct > 0 && (
               <span style={{ opacity: 0.6, fontWeight: 400, marginLeft: 4 }}>(cached)</span>
@@ -118,7 +139,7 @@ function TokenStatsCard({
           <span style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0, flexShrink: 1 }}>
             {sourceChip}
             {cache && (
-              <span title={cacheTitle} style={{ fontSize: 8, fontWeight: 700, padding: '1px 5px', borderRadius: 5, background: cache.bg, color: cache.color, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              <span title={cacheTitle} style={{ fontSize: 9, fontWeight: 700, padding: '1px 5px', borderRadius: 5, background: cache.bg, color: cache.color, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {cache.label}
               </span>
             )}
@@ -126,8 +147,28 @@ function TokenStatsCard({
         </div>
 
         {/* 대형 퍼센트 */}
-        <div style={{ fontSize: 30, fontWeight: 800, color: noData ? C.textMuted : barColor, lineHeight: 1.1, marginBottom: 6, fontFamily: C.fontMono }}>
-          {noData ? '—' : `${Math.round(barPct)}%`}
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8, marginBottom: 6 }}>
+          <div style={{ fontSize: 30, fontWeight: 800, color: noData ? C.textMuted : barColor, lineHeight: 1.1, fontFamily: C.fontMono }}>
+          {noData ? '—' : formatUsagePct(barPct)}
+          </div>
+          {!noData && timeGone != null && (
+            <div
+              title={`${Math.round(timeGone)}% of this ${period} window has elapsed`}
+              style={{
+                marginTop: 4,
+                fontSize: 9,
+                lineHeight: 1.25,
+                color: C.textMuted,
+                textAlign: 'right',
+                fontFamily: C.fontMono,
+                opacity: 0.78,
+                flexShrink: 0,
+              }}
+            >
+              <div style={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>time gone</div>
+              <div style={{ fontSize: 12, color: C.textDim }}>{Math.round(timeGone)}%</div>
+            </div>
+          )}
         </div>
 
         {/* 진행 바 (전폭) */}
@@ -150,7 +191,7 @@ function TokenStatsCard({
 
         {/* ETA 경고 */}
         {showEta && (
-          <div style={{ fontSize: 9, color: C.etaWarning, marginTop: 3 }}>
+          <div style={{ fontSize: 10, color: C.etaWarning, marginTop: 3 }}>
             ⚡ ~{fmtDuration(burnRate!.h5EtaMs!)} to limit
           </div>
         )}
@@ -158,7 +199,7 @@ function TokenStatsCard({
         {/* Footer: 리셋 왼쪽 ↔ 비용 오른쪽 */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginTop: 6 }}>
           {!noData && resetStr ? (
-            <span style={{ fontSize: 9, color: C.textMuted }}>{resetStr}</span>
+            <span style={{ fontSize: 10, color: C.textMuted }}>{resetStr}</span>
           ) : <span />}
           {!hideCost && stats.costUSD > 0 && (
             <span title="Usage window cost" style={{ fontSize: 12, fontWeight: 700, color: costColor, fontFamily: C.fontMono }}>{costStr}</span>
@@ -179,19 +220,19 @@ function TokenStatsCard({
         <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
           <span style={{ fontSize: 11, color: C.textMuted }}>{provider} · {period}</span>
           {!limitSourceLabel && apiConnected === false && limitPct != null && limitPct > 0 && (
-            <span style={{ fontSize: 8, color: C.textMuted, opacity: 0.6 }}>(cached)</span>
+            <span style={{ fontSize: 9, color: C.textMuted, opacity: 0.6 }}>(cached)</span>
           )}
           {sourceChip}
           {cache && (
-            <span title={cacheTitle} style={{ fontSize: 8, fontWeight: 700, padding: '1px 5px', borderRadius: 6, background: cache.bg, color: cache.color }}>
+            <span title={cacheTitle} style={{ fontSize: 9, fontWeight: 700, padding: '1px 5px', borderRadius: 6, background: cache.bg, color: cache.color }}>
               {cache.label}
             </span>
           )}
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>
-          <span style={{ fontSize: 10, color: C.textMuted }}>{fmtTokens(stats.totalTokens)} tok</span>
+          <span style={{ fontSize: 11, color: C.textMuted }}>{fmtTokens(stats.totalTokens)} tok</span>
           {stats.requestCount > 0 && (
-            <span style={{ fontSize: 10, color: C.textMuted }}>{stats.requestCount} req</span>
+            <span style={{ fontSize: 11, color: C.textMuted }}>{stats.requestCount} req</span>
           )}
           {!hideCost && (
             <span title="Usage window cost" style={{ fontSize: 12, fontWeight: 600, color: costColor }}>{costStr}</span>
@@ -213,11 +254,11 @@ function TokenStatsCard({
                 }} />
               )}
             </div>
-            <span style={{ fontSize: 10, fontWeight: 600, color: noData ? C.textMuted : barColor, width: 28, textAlign: 'right', flexShrink: 0, fontFamily: C.fontMono }}>
-              {noData ? '—' : `${Math.round(barPct)}%`}
+            <span style={{ fontSize: 11, fontWeight: 600, color: noData ? C.textMuted : barColor, width: 28, textAlign: 'right', flexShrink: 0, fontFamily: C.fontMono }}>
+              {noData ? '—' : formatUsagePct(barPct)}
             </span>
             {!noData && resetStr && (
-              <span style={{ fontSize: 9, color: C.textMuted, flexShrink: 0 }}>{resetStr}</span>
+              <span style={{ fontSize: 10, color: C.textMuted, flexShrink: 0 }}>{resetStr}</span>
             )}
           </div>
         );
@@ -225,7 +266,7 @@ function TokenStatsCard({
 
       {/* ETA 경고 */}
       {showEta && (
-        <div style={{ fontSize: 9, color: C.etaWarning, marginTop: 3 }}>
+        <div style={{ fontSize: 10, color: C.etaWarning, marginTop: 3 }}>
           ⚡ ~{fmtDuration(burnRate!.h5EtaMs!)} to limit at current rate
         </div>
       )}

--- a/src/renderer/components/TokenStatsCard.tsx
+++ b/src/renderer/components/TokenStatsCard.tsx
@@ -73,6 +73,45 @@ function TokenDotRow({ label, value, color }: { label: string; value: number; co
   );
 }
 
+function StackedProgressBar({
+  quotaPct,
+  timeGonePct,
+  quotaColor,
+  height = 8,
+}: {
+  quotaPct: number;
+  timeGonePct: number | null;
+  quotaColor: string;
+  height?: number;
+}) {
+  const C = useTheme();
+  const quota = Math.max(0, Math.min(100, quotaPct));
+  const gone = timeGonePct == null ? 0 : Math.max(0, Math.min(100, timeGonePct));
+  return (
+    <div style={{ position: 'relative', height, background: C.bgRow, borderRadius: height / 2, overflow: 'hidden' }}>
+      <div style={{
+        position: 'absolute',
+        inset: '0 auto 0 0',
+        width: `${gone}%`,
+        background: 'rgba(148,163,184,0.35)',
+        borderRadius: height / 2,
+        transition: 'width 0.4s',
+      }} />
+      <div style={{
+        position: 'absolute',
+        left: 0,
+        top: Math.max(1, Math.floor((height - 3) / 2)),
+        width: `${quota}%`,
+        height: 3,
+        background: quotaColor,
+        borderRadius: 3,
+        boxShadow: `0 0 8px ${quotaColor}55`,
+        transition: 'width 0.4s',
+      }} />
+    </div>
+  );
+}
+
 function TokenStatsCard({
   provider, period, stats, currency, usdToKrw,
   limitPct, resetMs, resetLabel, apiConnected, hideCost, burnRate,
@@ -172,13 +211,9 @@ function TokenStatsCard({
         </div>
 
         {/* 진행 바 (전폭) */}
-        <div style={{ height: 4, background: C.accentDim, borderRadius: 2, overflow: 'hidden', marginBottom: 6 }}>
+        <div style={{ marginBottom: 6 }}>
           {!noData && (
-            <div style={{
-              width: `${barPct}%`, height: '100%',
-              background: barColor, borderRadius: 2,
-              transition: 'width 0.4s',
-            }} />
+            <StackedProgressBar quotaPct={barPct} timeGonePct={timeGone} quotaColor={barColor} height={8} />
           )}
         </div>
 
@@ -245,13 +280,9 @@ function TokenStatsCard({
         const noData = apiConnected === false && barPct === 0 && limitSourceLabel !== 'live fallback' && limitSourceLabel !== 'local log';
         return (
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <div style={{ flex: 1, height: 5, background: C.accentDim, borderRadius: 3, overflow: 'hidden' }}>
+            <div style={{ flex: 1 }}>
               {!noData && (
-                <div style={{
-                  width: `${barPct}%`, height: '100%',
-                  background: barColor, borderRadius: 3,
-                  transition: 'width 0.4s',
-                }} />
+                <StackedProgressBar quotaPct={barPct} timeGonePct={timeGone} quotaColor={barColor} height={8} />
               )}
             </div>
             <span style={{ fontSize: 11, fontWeight: 600, color: noData ? C.textMuted : barColor, width: 28, textAlign: 'right', flexShrink: 0, fontFamily: C.fontMono }}>

--- a/src/renderer/components/TokenStatsCard.tsx
+++ b/src/renderer/components/TokenStatsCard.tsx
@@ -39,7 +39,7 @@ function windowDurationMs(period: string): number | null {
   return null;
 }
 
-function timeGonePct(period: string, resetMs: number | null | undefined): number | null {
+function timeElapsedPct(period: string, resetMs: number | null | undefined): number | null {
   const durationMs = windowDurationMs(period);
   if (!durationMs || resetMs == null || resetMs < 0 || resetMs > durationMs) return null;
   return Math.max(0, Math.min(100, ((durationMs - resetMs) / durationMs) * 100));
@@ -75,24 +75,24 @@ function TokenDotRow({ label, value, color }: { label: string; value: number; co
 
 function StackedProgressBar({
   quotaPct,
-  timeGonePct,
+  timeElapsedPct,
   quotaColor,
   height = 8,
 }: {
   quotaPct: number;
-  timeGonePct: number | null;
+  timeElapsedPct: number | null;
   quotaColor: string;
   height?: number;
 }) {
   const C = useTheme();
   const quota = Math.max(0, Math.min(100, quotaPct));
-  const gone = timeGonePct == null ? 0 : Math.max(0, Math.min(100, timeGonePct));
+  const elapsed = timeElapsedPct == null ? 0 : Math.max(0, Math.min(100, timeElapsedPct));
   return (
     <div style={{ position: 'relative', height, background: C.bgRow, borderRadius: height / 2, overflow: 'hidden' }}>
       <div style={{
         position: 'absolute',
         inset: '0 auto 0 0',
-        width: `${gone}%`,
+        width: `${elapsed}%`,
         background: 'rgba(148,163,184,0.35)',
         borderRadius: height / 2,
         transition: 'width 0.4s',
@@ -148,7 +148,7 @@ function TokenStatsCard({
   const cacheTitle = cacheBadgeTitle(cacheMetricMode);
   const showSavings = stats.cacheSavingsUSD > 0.005;
   const showEta = burnRate && burnRate.h5EtaMs !== null && resetMs != null && burnRate.h5EtaMs < resetMs;
-  const timeGone = timeGonePct(period, resetMs);
+  const timeElapsed = timeElapsedPct(period, resetMs);
   const sourceChip = limitSourceLabel ? (
     <span
       title={limitSourceLabel}
@@ -190,9 +190,9 @@ function TokenStatsCard({
           <div style={{ fontSize: 30, fontWeight: 800, color: noData ? C.textMuted : barColor, lineHeight: 1.1, fontFamily: C.fontMono }}>
           {noData ? '—' : formatUsagePct(barPct)}
           </div>
-          {!noData && timeGone != null && (
+          {!noData && timeElapsed != null && (
             <div
-              title={`${Math.round(timeGone)}% of this ${period} window has elapsed`}
+              title={`${Math.round(timeElapsed)}% of this ${period} window has elapsed`}
               style={{
                 marginTop: 4,
                 fontSize: 9,
@@ -204,8 +204,8 @@ function TokenStatsCard({
                 flexShrink: 0,
               }}
             >
-              <div style={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>time gone</div>
-              <div style={{ fontSize: 12, color: C.textDim }}>{Math.round(timeGone)}%</div>
+              <div style={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>time elapsed</div>
+              <div style={{ fontSize: 12, color: C.textDim }}>{Math.round(timeElapsed)}%</div>
             </div>
           )}
         </div>
@@ -213,7 +213,7 @@ function TokenStatsCard({
         {/* 진행 바 (전폭) */}
         <div style={{ marginBottom: 6 }}>
           {!noData && (
-            <StackedProgressBar quotaPct={barPct} timeGonePct={timeGone} quotaColor={barColor} height={8} />
+            <StackedProgressBar quotaPct={barPct} timeElapsedPct={timeElapsed} quotaColor={barColor} height={8} />
           )}
         </div>
 
@@ -282,7 +282,7 @@ function TokenStatsCard({
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <div style={{ flex: 1 }}>
               {!noData && (
-                <StackedProgressBar quotaPct={barPct} timeGonePct={timeGone} quotaColor={barColor} height={8} />
+                <StackedProgressBar quotaPct={barPct} timeElapsedPct={timeElapsed} quotaColor={barColor} height={8} />
               )}
             </div>
             <span style={{ fontSize: 11, fontWeight: 600, color: noData ? C.textMuted : barColor, width: 28, textAlign: 'right', flexShrink: 0, fontFamily: C.fontMono }}>

--- a/src/renderer/mainSections.ts
+++ b/src/renderer/mainSections.ts
@@ -1,0 +1,31 @@
+export const MAIN_SECTION_IDS = ['planUsage', 'codeOutput', 'sessions', 'activity', 'modelUsage'] as const;
+
+export type MainSectionId = typeof MAIN_SECTION_IDS[number];
+
+export const DEFAULT_MAIN_SECTION_ORDER: MainSectionId[] = [...MAIN_SECTION_IDS];
+
+export const MAIN_SECTION_LABELS: Record<MainSectionId, string> = {
+  planUsage: 'Plan Usage',
+  codeOutput: 'Code Output',
+  sessions: 'Sessions',
+  activity: 'Activity',
+  modelUsage: 'Model Usage',
+};
+
+export function normalizeMainSectionOrder(value: readonly string[] | null | undefined): MainSectionId[] {
+  const valid = new Set<string>(MAIN_SECTION_IDS);
+  const seen = new Set<string>();
+  const normalized: MainSectionId[] = [];
+
+  for (const id of value ?? []) {
+    if (!valid.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    normalized.push(id as MainSectionId);
+  }
+
+  for (const id of MAIN_SECTION_IDS) {
+    if (!seen.has(id)) normalized.push(id);
+  }
+
+  return normalized;
+}

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -164,6 +164,8 @@ export interface AppSettings {
   mainSectionOrder: MainSectionId[];
   hiddenProjects: string[];
   excludedProjects: string[];
+  compactWidgetEnabled: boolean;
+  compactWidgetBounds: { x: number; y: number } | null;
   theme: 'auto' | 'light' | 'dark';
 }
 
@@ -278,10 +280,16 @@ declare global {
       getIntegrationStatus: () => Promise<{ configured: boolean; command?: string }>;
       quit:               () => Promise<void>;
       minimize:           () => Promise<void>;
+      openDashboard:      () => Promise<void>;
+      openSettings:       () => Promise<void>;
+      hideCompactWidget:  () => Promise<void>;
+      getCompactWidgetPosition: () => Promise<{ x: number; y: number } | null>;
+      setCompactWidgetPosition: (p: { x: number; y: number }) => Promise<void>;
       isDebugInstrumentationEnabled: () => Promise<boolean>;
       getDebugMemSnapshot: () => Promise<DebugMemSnapshot | null>;
       reportDebugRendererEvent: (payload: Record<string, unknown>) => Promise<void>;
       onUpdated:          (cb: (state: AppState) => void) => () => void;
+      onNavigate:         (cb: (view: 'main' | 'settings' | 'notifications' | 'help') => void) => () => void;
       getResolvedTheme:   () => Promise<'light' | 'dark'>;
       onThemeChanged:     (cb: (theme: 'light' | 'dark') => void) => () => void;
     };

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -1,3 +1,5 @@
+import type { MainSectionId } from './mainSections';
+
 export interface GitStats {
   branch: string | null;
   toplevel: string | null;
@@ -153,11 +155,13 @@ export interface AppSettings {
   provider: 'claude' | 'codex' | 'both';
   alertThresholds: number[];
   openAtLogin: boolean;
+  alwaysOnTop: boolean;
   currency: 'USD' | 'KRW';
   usdToKrw: number;
   globalHotkey: string;
   enableAlerts: boolean;
   trayDisplay: 'none' | 'h5pct' | 'tokens' | 'cost';
+  mainSectionOrder: MainSectionId[];
   hiddenProjects: string[];
   excludedProjects: string[];
   theme: 'auto' | 'light' | 'dark';

--- a/src/renderer/views/CompactWidgetView.tsx
+++ b/src/renderer/views/CompactWidgetView.tsx
@@ -54,7 +54,7 @@ function windowDurationMs(label: string): number | null {
   return null;
 }
 
-function timeGonePct(label: string, resetMs: number | null): number | null {
+function timeElapsedPct(label: string, resetMs: number | null): number | null {
   const durationMs = windowDurationMs(label);
   if (!durationMs || resetMs == null || resetMs < 0 || resetMs > durationMs) return null;
   return clampPct(((durationMs - resetMs) / durationMs) * 100);
@@ -90,8 +90,8 @@ function ProgressRow({
 }) {
   const C = useTheme();
   const quota = clampPct(quotaPct);
-  const gone = timeGonePct(label, resetMs);
-  const goneWidth = gone ?? 0;
+  const elapsed = timeElapsedPct(label, resetMs);
+  const elapsedWidth = elapsed ?? 0;
   const resetLabel = formatResetShort(resetMs);
   const resetBadgeBg = C.bgCard === '#ffffff' ? 'rgba(255,255,255,0.68)' : 'rgba(0,0,0,0.22)';
 
@@ -105,7 +105,7 @@ function ProgressRow({
           style={{
             position: 'absolute',
             inset: '0 auto 0 0',
-            width: `${goneWidth}%`,
+            width: `${elapsedWidth}%`,
             background: 'rgba(148,163,184,0.35)',
             borderRadius: 4,
           }}
@@ -147,7 +147,7 @@ function ProgressRow({
       <div style={{ textAlign: 'right', color: C.textDim, fontSize: 10, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}>
         <span style={{ color }}>{formatPct(quota)}</span>
         <span style={{ color: C.textMuted }}> / </span>
-        <span>{formatPct(gone)}</span>
+        <span>{formatPct(elapsed)}</span>
       </div>
     </div>
   );

--- a/src/renderer/views/CompactWidgetView.tsx
+++ b/src/renderer/views/CompactWidgetView.tsx
@@ -1,0 +1,328 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AppState } from '../types';
+import { useTheme } from '../ThemeContext';
+
+interface Props {
+  state: AppState;
+  onRefresh: () => Promise<void>;
+}
+
+type WidgetAgent = {
+  key: 'claude' | 'codex';
+  label: string;
+  color: string;
+  rows: Array<{
+    key: string;
+    label: string;
+    quotaPct: number;
+    resetMs: number | null;
+  }>;
+};
+
+type DragState = {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  originX: number;
+  originY: number;
+};
+
+function formatRefreshLabel(lastUpdated: number): string {
+  if (!lastUpdated) return 'refresh';
+  const elapsed = Math.round((Date.now() - lastUpdated) / 1000);
+  if (elapsed < 60) return 'just now';
+  if (elapsed < 3600) return `${Math.floor(elapsed / 60)}m ago`;
+  return `${Math.floor(elapsed / 3600)}h ago`;
+}
+
+function formatPct(pct: number | null): string {
+  if (pct == null) return '--';
+  if (pct <= 0) return '0%';
+  if (pct < 1) return '<1%';
+  if (pct < 10) return `${Math.round(pct * 10) / 10}%`;
+  return `${Math.round(pct)}%`;
+}
+
+function clampPct(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+}
+
+function windowDurationMs(label: string): number | null {
+  if (label === '5h') return 5 * 60 * 60 * 1000;
+  if (label === '1w') return 7 * 24 * 60 * 60 * 1000;
+  return null;
+}
+
+function timeGonePct(label: string, resetMs: number | null): number | null {
+  const durationMs = windowDurationMs(label);
+  if (!durationMs || resetMs == null || resetMs < 0 || resetMs > durationMs) return null;
+  return clampPct(((durationMs - resetMs) / durationMs) * 100);
+}
+
+function formatResetShort(resetMs: number | null): string {
+  if (resetMs == null || resetMs <= 0) return '--';
+  if (resetMs > 4 * 24 * 3600 * 1000) {
+    return ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][new Date(Date.now() + resetMs).getDay()];
+  }
+  const totalMinutes = Math.max(1, Math.round(resetMs / 60000));
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours >= 10 || minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes}m`;
+}
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && !!target.closest('[data-no-drag="true"]');
+}
+
+function ProgressRow({
+  label,
+  quotaPct,
+  resetMs,
+  color,
+}: {
+  label: string;
+  quotaPct: number;
+  resetMs: number | null;
+  color: string;
+}) {
+  const C = useTheme();
+  const quota = clampPct(quotaPct);
+  const gone = timeGonePct(label, resetMs);
+  const goneWidth = gone ?? 0;
+  const resetLabel = formatResetShort(resetMs);
+  const resetBadgeBg = C.bgCard === '#ffffff' ? 'rgba(255,255,255,0.68)' : 'rgba(0,0,0,0.22)';
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '24px minmax(0, 1fr) 70px', alignItems: 'center', gap: 7 }}>
+      <div style={{ color: C.textMuted, fontSize: 10, fontFamily: C.fontMono, fontWeight: 700 }}>
+        {label}
+      </div>
+      <div style={{ position: 'relative', height: 8, background: C.bgRow, borderRadius: 4, overflow: 'hidden' }}>
+        <div
+          style={{
+            position: 'absolute',
+            inset: '0 auto 0 0',
+            width: `${goneWidth}%`,
+            background: 'rgba(148,163,184,0.35)',
+            borderRadius: 4,
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 2,
+            width: `${quota}%`,
+            height: 3,
+            background: color,
+            borderRadius: 3,
+            boxShadow: `0 0 8px ${color}66`,
+          }}
+        />
+        <span
+          title="Time until reset"
+          style={{
+            position: 'absolute',
+            right: 4,
+            top: -1,
+            maxWidth: 52,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontSize: 8,
+            lineHeight: '10px',
+            fontFamily: C.fontMono,
+            color: C.textDim,
+            background: resetBadgeBg,
+            borderRadius: 3,
+            padding: '0 3px',
+          }}
+        >
+          {resetLabel}
+        </span>
+      </div>
+      <div style={{ textAlign: 'right', color: C.textDim, fontSize: 10, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}>
+        <span style={{ color }}>{formatPct(quota)}</span>
+        <span style={{ color: C.textMuted }}> / </span>
+        <span>{formatPct(gone)}</span>
+      </div>
+    </div>
+  );
+}
+
+function AgentBlock({ agent }: { agent: WidgetAgent }) {
+  const C = useTheme();
+  return (
+    <div style={{ display: 'grid', gap: 4 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span style={{ width: 6, height: 6, borderRadius: '50%', background: agent.color, boxShadow: `0 0 8px ${agent.color}88` }} />
+        <span style={{ fontSize: 11, fontWeight: 800, color: C.text, lineHeight: 1 }}>
+          {agent.label}
+        </span>
+      </div>
+      <div style={{ display: 'grid', gap: 4 }}>
+        {agent.rows.map(row => (
+          <ProgressRow key={row.key} label={row.label} quotaPct={row.quotaPct} resetMs={row.resetMs} color={agent.color} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function CompactWidgetView({ state, onRefresh }: Props) {
+  const C = useTheme();
+  const [refreshLabel, setRefreshLabel] = useState(() => formatRefreshLabel(state.lastUpdated));
+  const [refreshing, setRefreshing] = useState(false);
+  const dragRef = useRef<DragState | null>(null);
+  const movedRef = useRef(false);
+
+  useEffect(() => {
+    setRefreshLabel(formatRefreshLabel(state.lastUpdated));
+    const timer = window.setInterval(() => setRefreshLabel(formatRefreshLabel(state.lastUpdated)), 30_000);
+    return () => window.clearInterval(timer);
+  }, [state.lastUpdated]);
+
+  const agents = useMemo<WidgetAgent[]>(() => {
+    const provider = state.settings.provider ?? 'both';
+    const next: WidgetAgent[] = [];
+    if (provider !== 'codex') {
+      next.push({
+        key: 'claude',
+        label: 'Claude',
+        color: C.sonnet,
+        rows: [
+          { key: 'claude-5h', label: '5h', quotaPct: state.limits.h5.pct, resetMs: state.limits.h5.resetMs },
+          { key: 'claude-1w', label: '1w', quotaPct: state.limits.week.pct, resetMs: state.limits.week.resetMs },
+        ],
+      });
+    }
+    if (provider !== 'claude') {
+      next.push({
+        key: 'codex',
+        label: 'Codex',
+        color: C.active,
+        rows: [
+          { key: 'codex-5h', label: '5h', quotaPct: state.limits.codexH5.pct, resetMs: state.limits.codexH5.resetMs },
+          { key: 'codex-1w', label: '1w', quotaPct: state.limits.codexWeek.pct, resetMs: state.limits.codexWeek.resetMs },
+        ],
+      });
+    }
+    return next;
+  }, [C.active, C.sonnet, state.limits.codexH5.pct, state.limits.codexH5.resetMs, state.limits.codexWeek.pct, state.limits.codexWeek.resetMs, state.limits.h5.pct, state.limits.h5.resetMs, state.limits.week.pct, state.limits.week.resetMs, state.settings.provider]);
+
+  const handleRefresh = useCallback(async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    setRefreshLabel('refreshing');
+    try {
+      await onRefresh();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [onRefresh, refreshing]);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || isInteractiveTarget(event.target)) return;
+    movedRef.current = false;
+    const startX = event.screenX;
+    const startY = event.screenY;
+    const pointerId = event.pointerId;
+    event.currentTarget.setPointerCapture(pointerId);
+    window.wmt.getCompactWidgetPosition().then(position => {
+      if (!position) return;
+      dragRef.current = { pointerId, startX, startY, originX: position.x, originY: position.y };
+    }).catch(() => {});
+  }, []);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const dx = event.screenX - drag.startX;
+    const dy = event.screenY - drag.startY;
+    if (Math.abs(dx) > 2 || Math.abs(dy) > 2) movedRef.current = true;
+    window.wmt.setCompactWidgetPosition({ x: drag.originX + dx, y: drag.originY + dy }).catch(() => {});
+  }, []);
+
+  const handlePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (drag?.pointerId === event.pointerId) dragRef.current = null;
+  }, []);
+
+  const handleDoubleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (isInteractiveTarget(event.target) || movedRef.current) return;
+    window.wmt.openDashboard().catch(() => {});
+  }, []);
+
+  return (
+    <div
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onDoubleClick={handleDoubleClick}
+      style={{
+        height: '100vh',
+        boxSizing: 'border-box',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 7,
+        padding: '8px 10px',
+        background: C.bgCard,
+        color: C.text,
+        fontFamily: C.fontSans,
+        overflow: 'hidden',
+        cursor: 'move',
+        userSelect: 'none',
+        boxShadow: 'none',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, minHeight: 13 }}>
+        <span style={{ fontSize: 10, fontWeight: 900, color: C.textDim, letterSpacing: 0, lineHeight: 1 }}>
+          Plan Usage vs Time Elapsed
+        </span>
+        <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            data-no-drag="true"
+            onClick={handleRefresh}
+            title="Refresh now"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: refreshing ? C.accent : C.textMuted,
+              cursor: refreshing ? 'wait' : 'pointer',
+              fontSize: 10,
+              fontFamily: C.fontMono,
+              padding: 0,
+              lineHeight: 1,
+            }}
+          >
+            {refreshLabel}
+          </button>
+          <button
+            data-no-drag="true"
+            onClick={() => window.wmt.openDashboard().catch(() => {})}
+            title="Open dashboard"
+            style={{ background: 'none', border: 'none', color: C.textMuted, cursor: 'pointer', fontSize: 11, padding: 0, lineHeight: 1 }}
+          >
+            ^
+          </button>
+          <button
+            data-no-drag="true"
+            onClick={() => window.wmt.hideCompactWidget().catch(() => {})}
+            title="Hide widget"
+            style={{ background: 'none', border: 'none', color: C.textMuted, cursor: 'pointer', fontSize: 12, padding: 0, lineHeight: 1 }}
+          >
+            x
+          </button>
+        </span>
+      </div>
+
+      <div style={{ display: 'grid', gap: agents.length > 1 ? 9 : 6 }}>
+        {agents.map(agent => <AgentBlock key={agent.key} agent={agent} />)}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/views/HelpView.tsx
+++ b/src/renderer/views/HelpView.tsx
@@ -71,7 +71,7 @@ function SrcRow({ badge, children }: { badge: '1st' | '2nd' | 'FB'; children: Re
   return (
     <div style={{ display: 'flex', gap: 8, marginBottom: 7, alignItems: 'flex-start' }}>
       <span style={{
-        fontSize: 10, fontWeight: 700, padding: '2px 6px',
+        fontSize: 11, fontWeight: 700, padding: '2px 6px',
         borderRadius: 3, whiteSpace: 'nowrap' as const, marginTop: 1, flexShrink: 0,
         background: s.bg, color: s.color,
       }}>{badge}</span>
@@ -87,7 +87,7 @@ function CatRow({ icon, label, color, children }: {
   return (
     <div style={{ display: 'flex', gap: 8, marginBottom: 5, alignItems: 'flex-start' }}>
       <span style={{
-        fontSize: 9.5, fontWeight: 700, padding: '2px 6px',
+        fontSize: 10.5, fontWeight: 700, padding: '2px 6px',
         borderRadius: 3, whiteSpace: 'nowrap' as const, flexShrink: 0,
         background: color + '20', color, border: `1px solid ${color}44`,
         display: 'inline-flex', alignItems: 'center', gap: 3,
@@ -105,7 +105,7 @@ function UsageTable({ rows, headers }: {
 }) {
   const C = useTheme();
   const TH: React.CSSProperties = {
-    textAlign: 'left', fontSize: 10.5, fontWeight: 600,
+    textAlign: 'left', fontSize: 11.5, fontWeight: 600,
     color: C.textMuted, paddingBottom: 5, paddingRight: 8,
     borderBottom: `1px solid ${C.borderSub}`,
   };
@@ -481,7 +481,7 @@ export default function HelpView({ onBack }: Props) {
       <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '6px 16px 0', gap: 4, flexShrink: 0 }}>
         {(['en', 'ko', 'ja'] as Lang[]).map(l => (
           <button key={l} onClick={() => setLang(l)} style={{
-            padding: '2px 8px', fontSize: 10, border: 'none', borderRadius: 10, cursor: 'pointer',
+            padding: '2px 8px', fontSize: 11, border: 'none', borderRadius: 10, cursor: 'pointer',
             background: lang === l ? C.accent : C.bgRow,
             color: lang === l ? '#fff' : C.textDim,
             fontWeight: lang === l ? 700 : 400,

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -9,6 +9,7 @@ import ModelBreakdown from '../components/ModelBreakdown';
 import ExtraUsageCard from '../components/ExtraUsageCard';
 import CodeOutputCard from '../components/CodeOutputCard';
 import RenderErrorBoundary from '../components/RenderErrorBoundary';
+import { MainSectionId, normalizeMainSectionOrder } from '../mainSections';
 
 interface Props {
   state: AppState;
@@ -95,7 +96,7 @@ function headerPeriodButtonStyle(
   return {
     ...noDrag,
     padding: '2px 6px',
-    fontSize: 9,
+    fontSize: 10,
     borderRadius: 3,
     cursor: 'pointer',
     fontFamily: C.fontMono,
@@ -371,7 +372,7 @@ const HeaderMetrics = React.memo(function HeaderMetrics({ state, onQuit }: { sta
             <span
               title={headerStatus.title}
               style={{
-                fontSize: 9,
+                fontSize: 10,
                 borderRadius: 999,
                 padding: '2px 8px',
                 fontWeight: 700,
@@ -395,7 +396,7 @@ const HeaderMetrics = React.memo(function HeaderMetrics({ state, onQuit }: { sta
       <div style={{ ...drag, display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) auto', gap: 14, padding: '4px 14px 10px', alignItems: 'end', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
         <div style={{ minWidth: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0, marginBottom: 3 }}>
-            <div style={{ fontSize: 8, color: C.headerSub, textTransform: 'uppercase', letterSpacing: 1.1, whiteSpace: 'nowrap' }}>
+            <div style={{ fontSize: 9, color: C.headerSub, textTransform: 'uppercase', letterSpacing: 1.1, whiteSpace: 'nowrap' }}>
               {isAll ? 'All-time Cost' : 'Today Cost'}
             </div>
           </div>
@@ -404,7 +405,7 @@ const HeaderMetrics = React.memo(function HeaderMetrics({ state, onQuit }: { sta
               {planLabel && (
                 <div title={`Claude plan: ${planLabel}`} style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 }}>
                   <span style={{
-                    fontSize: 8,
+                    fontSize: 9,
                     color: C.textMuted,
                     background: C.bgRow,
                     border: `1px solid ${C.border}`,
@@ -415,7 +416,7 @@ const HeaderMetrics = React.memo(function HeaderMetrics({ state, onQuit }: { sta
                   }}>
                     Claude
                   </span>
-                  <span style={{ fontSize: 9, color: C.headerSub, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}>
+                  <span style={{ fontSize: 10, color: C.headerSub, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}>
                     {planLabel}
                   </span>
                 </div>
@@ -423,7 +424,7 @@ const HeaderMetrics = React.memo(function HeaderMetrics({ state, onQuit }: { sta
               {codexTierLabel && (
                 <div title={`Codex service tier: ${codexTierLabel}`} style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 }}>
                   <span style={{
-                    fontSize: 8,
+                    fontSize: 9,
                     color: C.textMuted,
                     background: C.bgRow,
                     border: `1px solid ${C.border}`,
@@ -434,7 +435,7 @@ const HeaderMetrics = React.memo(function HeaderMetrics({ state, onQuit }: { sta
                   }}>
                     Codex
                   </span>
-                  <span style={{ fontSize: 9, color: C.headerSub, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}>
+                  <span style={{ fontSize: 10, color: C.headerSub, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}>
                     {codexTierLabel}
                   </span>
                 </div>
@@ -444,20 +445,20 @@ const HeaderMetrics = React.memo(function HeaderMetrics({ state, onQuit }: { sta
           <div style={{ fontSize: 28, fontWeight: 800, color: C.headerText, lineHeight: 1, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}>
             {fmtCost(cost, currency, usdToKrw)}
           </div>
-          <div style={{ fontSize: 10, color: C.headerSub, marginTop: 4, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          <div style={{ fontSize: 11, color: C.headerSub, marginTop: 4, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
             <span style={{ fontFamily: C.fontMono, fontWeight: 700, color: C.headerText }}>{fmtTokens(calls)}</span> calls
             <span style={{ margin: '0 6px', color: C.textMuted }}>/</span>
             <span style={{ fontFamily: C.fontMono, fontWeight: 700, color: C.headerText }}>{sessionCount}</span> sessions
           </div>
         </div>
         <div style={{ textAlign: 'right', minWidth: 0 }} title={cacheTitle}>
-          <div style={{ fontSize: 8, color: C.headerSub, textTransform: 'uppercase', letterSpacing: 1.1, marginBottom: 3, whiteSpace: 'nowrap' }}>
+          <div style={{ fontSize: 9, color: C.headerSub, textTransform: 'uppercase', letterSpacing: 1.1, marginBottom: 3, whiteSpace: 'nowrap' }}>
             {isAll ? 'Avg Cache Efficiency' : 'Cache Efficiency'}
           </div>
           <div style={{ fontSize: 24, fontWeight: 800, color: cacheColor, lineHeight: 1, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}>
             {Math.round(cacheEff)}%
           </div>
-          <div style={{ fontSize: 10, color: cacheColor, marginTop: 4, whiteSpace: 'nowrap' }}>
+          <div style={{ fontSize: 11, color: cacheColor, marginTop: 4, whiteSpace: 'nowrap' }}>
             + {fmtCost(saved, currency, usdToKrw)} saved{isAll ? ' total' : ' today'}
           </div>
         </div>
@@ -494,7 +495,7 @@ const PlanUsagePanel = React.memo(function PlanUsagePanel({ usage, limits, setti
   return (
     <div style={{ margin: '10px 8px 0', background: C.bgCard, borderRadius: 10, overflow: 'hidden', border: `1px solid ${C.border}` }}>
       <div style={{ display: 'flex', alignItems: 'center', padding: '6px 14px 5px 12px', background: C.bgRow, borderBottom: `1px solid ${C.border}` }}>
-        <span style={{ fontSize: 10, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Plan Usage</span>
+        <span style={{ fontSize: 11, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Plan Usage</span>
       </div>
 
       {showClaudeUsage && (
@@ -553,7 +554,7 @@ const HistoryWarmupBanner = React.memo(function HistoryWarmupBanner({ historyWar
       background: `${C.headerAccent}10`,
       color: C.textDim,
     }}>
-      <div style={{ fontSize: 10, fontWeight: 700, color: C.headerAccent, textTransform: 'uppercase', letterSpacing: 0.8 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, color: C.headerAccent, textTransform: 'uppercase', letterSpacing: 0.8 }}>
         Partial History
       </div>
       <div style={{ fontSize: 11, lineHeight: 1.5, marginTop: 3 }}>
@@ -594,23 +595,23 @@ const SessionStackRow = React.memo(function SessionStackRow({ item, expanded, on
       <span style={{ minWidth: 0 }}>
         <span style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 }}>
           {item.modelName && (
-            <span title={item.modelName} style={{ fontSize: 8, background: `${modelColorValue}16`, color: modelColorValue, border: `1px solid ${modelColorValue}33`, borderRadius: 3, padding: '1px 5px', fontWeight: 700, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span title={item.modelName} style={{ fontSize: 9, background: `${modelColorValue}16`, color: modelColorValue, border: `1px solid ${modelColorValue}33`, borderRadius: 3, padding: '1px 5px', fontWeight: 700, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {item.modelName}
             </span>
           )}
-          <span style={{ fontSize: 8, background: item.provider === 'codex' ? C.output + '16' : C.accentDim, color: item.provider === 'codex' ? C.output : C.textMuted, border: `1px solid ${C.border}`, borderRadius: 3, padding: '1px 5px', fontWeight: 700 }}>
+          <span style={{ fontSize: 9, background: item.provider === 'codex' ? C.output + '16' : C.accentDim, color: item.provider === 'codex' ? C.output : C.textMuted, border: `1px solid ${C.border}`, borderRadius: 3, padding: '1px 5px', fontWeight: 700 }}>
             {provider}
           </span>
           <span style={{ fontSize: 11, fontWeight: 700, color: C.text }}>
             {item.sessions.length} {item.state} sessions
           </span>
         </span>
-        <span style={{ display: 'block', fontSize: 9, color: C.textMuted, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        <span style={{ display: 'block', fontSize: 10, color: C.textMuted, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {item.source} - latest {fmtRelative(item.latest)} - max ctx {Math.round(item.maxCtxPct)}%
         </span>
       </span>
       <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-        <span style={{ fontSize: 8, padding: '1px 5px', borderRadius: 3, background: `${chipColor}1a`, color: chipColor, fontWeight: 700 }}>
+        <span style={{ fontSize: 9, padding: '1px 5px', borderRadius: 3, background: `${chipColor}1a`, color: chipColor, fontWeight: 700 }}>
           {expanded ? 'open' : 'stack'}
         </span>
         <span style={{ fontSize: 12, color: C.textMuted }}>{expanded ? '^' : 'v'}</span>
@@ -758,7 +759,7 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
   return (
     <div style={{ margin: '10px 8px 0', background: C.bgCard, borderRadius: 10, overflow: 'hidden', border: `1px solid ${C.border}`, paddingBottom: 16, contain: 'layout paint style', overflowAnchor: 'none' }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 14px 5px 12px', background: C.bgRow, borderBottom: `1px solid ${C.border}` }}>
-        <span style={{ fontSize: 10, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Sessions</span>
+        <span style={{ fontSize: 11, fontWeight: 600, color: C.textDim, textTransform: 'uppercase', letterSpacing: 0.8 }}>Sessions</span>
         <div style={{ display: 'flex', gap: 4 }}>
           {(['all', 'active'] as const).map(filter => (
             <button
@@ -768,7 +769,7 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
                 background: activeFilter === filter ? C.accent + '22' : 'none',
                 border: `1px solid ${activeFilter === filter ? C.accent + '66' : C.border}`,
                 color: activeFilter === filter ? C.accent : C.textMuted,
-                borderRadius: 3, padding: '1px 7px', fontSize: 9, cursor: 'pointer', fontWeight: activeFilter === filter ? 700 : 400,
+                borderRadius: 3, padding: '1px 7px', fontSize: 10, cursor: 'pointer', fontWeight: activeFilter === filter ? 700 : 400,
               }}
             >
               {filter === 'all' ? 'All' : 'Active'}
@@ -788,7 +789,7 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
               <span style={{ fontSize: 13, fontWeight: 700, color: C.text, fontFamily: C.fontSans }}>{project.name}</span>
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 {project.totalCommits > 0 && (
-                  <span style={{ fontSize: 9, color: C.textMuted, fontFamily: C.fontMono }}>
+                  <span style={{ fontSize: 10, color: C.textMuted, fontFamily: C.fontMono }}>
                     {project.totalCommits} commit{project.totalCommits > 1 ? 's' : ''} · +{project.totalAdded} / -{project.totalRemoved}
                   </span>
                 )}
@@ -802,8 +803,8 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
                   </button>
                   {projectMenuOpen === project.name && (
                     <div style={{ position: 'absolute', right: 0, top: 20, zIndex: 5, display: 'grid', gap: 2, padding: 4, background: C.bgCard, border: `1px solid ${C.border}`, borderRadius: 6, boxShadow: '0 4px 10px rgba(0,0,0,0.18)' }}>
-                      <button onClick={() => hideProject(project.name)} style={{ background: C.bgRow, border: `1px solid ${C.border}`, color: C.textDim, cursor: 'pointer', fontSize: 10, padding: '3px 8px', borderRadius: 3, textAlign: 'left' }}>Hide</button>
-                      <button onClick={() => excludeProject(project.name)} style={{ background: C.bgRow, border: `1px solid ${C.border}`, color: C.textDim, cursor: 'pointer', fontSize: 10, padding: '3px 8px', borderRadius: 3, textAlign: 'left' }}>Exclude</button>
+                      <button onClick={() => hideProject(project.name)} style={{ background: C.bgRow, border: `1px solid ${C.border}`, color: C.textDim, cursor: 'pointer', fontSize: 11, padding: '3px 8px', borderRadius: 3, textAlign: 'left' }}>Hide</button>
+                      <button onClick={() => excludeProject(project.name)} style={{ background: C.bgRow, border: `1px solid ${C.border}`, color: C.textDim, cursor: 'pointer', fontSize: 11, padding: '3px 8px', borderRadius: 3, textAlign: 'left' }}>Exclude</button>
                     </div>
                   )}
                 </div>
@@ -820,16 +821,16 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
                 <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '3px 0', flexWrap: 'wrap' }}>
                   <span style={{ fontSize: 11, color: C.accent, lineHeight: 1 }} aria-hidden="true">›</span>
                   <span title={branch.branch} style={{
-                    fontSize: 10, color: C.textDim, fontWeight: 500, fontFamily: C.fontMono,
+                    fontSize: 11, color: C.textDim, fontWeight: 500, fontFamily: C.fontMono,
                     maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
                   }}>{branch.branch}</span>
                   {branch.commits > 0 && (
                     <>
-                      <span style={{ fontSize: 8, background: '#60a5fa1a', color: '#60a5fa', borderRadius: 3, padding: '1px 5px', fontFamily: C.fontMono, fontWeight: 600 }}>
+                      <span style={{ fontSize: 9, background: '#60a5fa1a', color: '#60a5fa', borderRadius: 3, padding: '1px 5px', fontFamily: C.fontMono, fontWeight: 600 }}>
                         {branch.commits} commit{branch.commits > 1 ? 's' : ''}
                       </span>
-                      <span style={{ fontSize: 8, background: '#34d3991a', color: '#34d399', borderRadius: 3, padding: '1px 5px', fontFamily: C.fontMono, fontWeight: 600 }}>+{branch.added}</span>
-                      <span style={{ fontSize: 8, background: '#f871711a', color: '#f87171', borderRadius: 3, padding: '1px 5px', fontFamily: C.fontMono, fontWeight: 600 }}>-{branch.removed}</span>
+                      <span style={{ fontSize: 9, background: '#34d3991a', color: '#34d399', borderRadius: 3, padding: '1px 5px', fontFamily: C.fontMono, fontWeight: 600 }}>+{branch.added}</span>
+                      <span style={{ fontSize: 9, background: '#f871711a', color: '#f87171', borderRadius: 3, padding: '1px 5px', fontFamily: C.fontMono, fontWeight: 600 }}>-{branch.removed}</span>
                     </>
                   )}
                 </div>
@@ -869,7 +870,7 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
                       color: C.textMuted,
                       borderRadius: 8,
                       cursor: 'pointer',
-                      fontSize: 9,
+                      fontSize: 10,
                       padding: '3px 8px',
                       fontFamily: C.fontMono,
                     }}
@@ -888,7 +889,7 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
                       color: C.textMuted,
                       borderRadius: 8,
                       cursor: 'pointer',
-                      fontSize: 9,
+                      fontSize: 10,
                       padding: '3px 8px',
                       fontFamily: C.fontMono,
                     }}
@@ -911,7 +912,7 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
             onClick={() => setShowStale(v => !v)}
             style={{
               background: 'none', border: `1px solid ${C.border}`, borderRadius: 10,
-              color: C.textMuted, cursor: 'pointer', fontSize: 9, padding: '3px 12px',
+              color: C.textMuted, cursor: 'pointer', fontSize: 10, padding: '3px 12px',
               fontFamily: C.fontMono,
             }}
           >
@@ -924,7 +925,7 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
         <div style={{ padding: '4px 14px', marginTop: 8, borderTop: `1px solid ${C.border}` }}>
           <button
             onClick={() => setShowHiddenManager(v => !v)}
-            style={{ background: 'none', border: 'none', color: C.textMuted, cursor: 'pointer', fontSize: 10, padding: 0 }}
+            style={{ background: 'none', border: 'none', color: C.textMuted, cursor: 'pointer', fontSize: 11, padding: 0 }}
           >
             {showHiddenManager ? 'v' : '>'} {hiddenProjects.length} hidden project{hiddenProjects.length > 1 ? 's' : ''}
           </button>
@@ -935,7 +936,7 @@ const SessionsPanel = React.memo(function SessionsPanel({ sessions, settings, pr
                   <span style={{ fontSize: 11, color: C.textDim, flex: 1 }}>{name}</span>
                   <button
                     onClick={() => unhideProject(name)}
-                    style={{ background: 'none', border: `1px solid ${C.border}`, color: C.textDim, cursor: 'pointer', fontSize: 10, padding: '1px 6px', borderRadius: 3 }}
+                    style={{ background: 'none', border: `1px solid ${C.border}`, color: C.textDim, cursor: 'pointer', fontSize: 11, padding: '1px 6px', borderRadius: 3 }}
                   >show</button>
                 </div>
               ))}
@@ -1010,7 +1011,7 @@ const BottomNav = React.memo(function BottomNav({ lastUpdated, refreshing, synci
             flex: 1, padding: '7px 0', background: 'none', border: 'none',
             color: key === 'refresh' && refreshing ? C.accent : C.textDim,
             cursor: key === 'refresh' && refreshing ? 'wait' : 'pointer',
-            fontSize: 10, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2,
+            fontSize: 11, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2,
           }}
         >
           <span style={{
@@ -1039,6 +1040,7 @@ export default function MainView({ state, onNav, onQuit, onRefresh, onScrollActi
     () => sessions.map(s => `${s.sessionId}:${s.provider}:${s.source}:${s.state}:${s.projectName}:${s.worktreeBranch ?? s.gitBranch ?? ''}:${s.modelName}`).join('|'),
     [sessions]
   );
+  const mainSectionOrder = useMemo(() => normalizeMainSectionOrder(settings.mainSectionOrder), [settings.mainSectionOrder]);
 
   const handleScroll = useCallback(() => {
     const node = scrollRef.current;
@@ -1068,6 +1070,43 @@ export default function MainView({ state, onNav, onQuit, onRefresh, onScrollActi
     setRefreshing(false);
   }, [refreshing, onRefresh]);
 
+  const renderMainSection = useCallback((sectionId: MainSectionId) => {
+    switch (sectionId) {
+      case 'planUsage':
+        return (
+          <RenderErrorBoundary key={sectionId} label="Plan Usage Panel">
+            <PlanUsagePanel usage={usage} limits={state.limits} settings={settings} apiConnected={state.apiConnected} extraUsage={state.extraUsage} />
+          </RenderErrorBoundary>
+        );
+      case 'codeOutput':
+        return (
+          <RenderErrorBoundary key={sectionId} label="Code Output Card">
+            <CodeOutputCard stats={state.codeOutputStats} loading={state.codeOutputLoading} todayCost={usage.todayCost} allTimeCost={allTimeCost} currency={currency} usdToKrw={usdToKrw} />
+          </RenderErrorBoundary>
+        );
+      case 'sessions':
+        return (
+          <RenderErrorBoundary key={sectionId} label="Sessions Panel">
+            <SessionsPanel sessions={sessions} settings={settings} providerMode={providerMode} />
+          </RenderErrorBoundary>
+        );
+      case 'activity':
+        return (
+          <RenderErrorBoundary key={sectionId} label="Activity Section">
+            <ActivitySection usage={usage} currency={currency} usdToKrw={usdToKrw} />
+          </RenderErrorBoundary>
+        );
+      case 'modelUsage':
+        return (
+          <RenderErrorBoundary key={sectionId} label="Model Section">
+            <ModelSection models={usage.models} currency={currency} usdToKrw={usdToKrw} />
+          </RenderErrorBoundary>
+        );
+      default:
+        return null;
+    }
+  }, [allTimeCost, currency, providerMode, sessions, settings, state.apiConnected, state.codeOutputLoading, state.codeOutputStats, state.extraUsage, state.limits, usage, usdToKrw]);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: C.bg, color: C.text, overflow: 'hidden' }}>
       <RenderErrorBoundary label="Header Metrics">
@@ -1079,21 +1118,7 @@ export default function MainView({ state, onNav, onQuit, onRefresh, onScrollActi
             <HistoryWarmupBanner historyWarmupStartsAt={state.historyWarmupStartsAt} />
           </RenderErrorBoundary>
         )}
-        <RenderErrorBoundary label="Plan Usage Panel">
-          <PlanUsagePanel usage={usage} limits={state.limits} settings={settings} apiConnected={state.apiConnected} extraUsage={state.extraUsage} />
-        </RenderErrorBoundary>
-        <RenderErrorBoundary label="Code Output Card">
-          <CodeOutputCard stats={state.codeOutputStats} loading={state.codeOutputLoading} todayCost={usage.todayCost} allTimeCost={allTimeCost} currency={currency} usdToKrw={usdToKrw} />
-        </RenderErrorBoundary>
-        <RenderErrorBoundary label="Sessions Panel">
-          <SessionsPanel sessions={sessions} settings={settings} providerMode={providerMode} />
-        </RenderErrorBoundary>
-        <RenderErrorBoundary label="Activity Section">
-          <ActivitySection usage={usage} currency={currency} usdToKrw={usdToKrw} />
-        </RenderErrorBoundary>
-        <RenderErrorBoundary label="Model Section">
-          <ModelSection models={usage.models} currency={currency} usdToKrw={usdToKrw} />
-        </RenderErrorBoundary>
+        {mainSectionOrder.map(renderMainSection)}
       </div>
       <RenderErrorBoundary label="Bottom Navigation">
         <BottomNav

--- a/src/renderer/views/NotificationsView.tsx
+++ b/src/renderer/views/NotificationsView.tsx
@@ -18,7 +18,7 @@ export default function NotificationsView({ onBack }: Props) {
     borderBottom: `1px solid ${C.border}`,
   }), [C]);
   const labelStyle: React.CSSProperties = useMemo(() => ({ fontSize: 12, color: C.text }), [C]);
-  const sub: React.CSSProperties = useMemo(() => ({ fontSize: 10, color: C.textMuted, marginTop: 2 }), [C]);
+  const sub: React.CSSProperties = useMemo(() => ({ fontSize: 11, color: C.textMuted, marginTop: 2 }), [C]);
   const chk: React.CSSProperties = useMemo(() => ({ accentColor: C.accent, width: 16, height: 16, cursor: 'pointer' }), [C]);
 
   useEffect(() => {
@@ -52,7 +52,7 @@ export default function NotificationsView({ onBack }: Props) {
   function SectionHeader({ text }: { text: string }) {
     return (
       <div style={{
-        fontSize: 10,
+        fontSize: 11,
         color: C.textMuted,
         textTransform: 'uppercase',
         letterSpacing: 0.5,

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -173,6 +173,15 @@ export default function SettingsView({ settings, onSave, onBack }: Props) {
           <input type="checkbox" style={chk} checked={s.alwaysOnTop} onChange={e => setS({ ...s, alwaysOnTop: e.target.checked })} />
         </div>
         <div style={row}>
+          <div>
+            <div style={labelStyle}>Compact widget</div>
+            <div style={{ fontSize: 10, color: C.textMuted, marginTop: 2 }}>
+              Small always-on-top quota widget
+            </div>
+          </div>
+          <input type="checkbox" style={chk} checked={s.compactWidgetEnabled} onChange={e => setS({ ...s, compactWidgetEnabled: e.target.checked })} />
+        </div>
+        <div style={row}>
           <span style={labelStyle}>Global shortcut</span>
           <input
             readOnly

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -2,12 +2,61 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { AppSettings } from '../types';
 import { useTheme } from '../ThemeContext';
 import ViewHeader from '../components/ViewHeader';
+import { DEFAULT_MAIN_SECTION_ORDER, MAIN_SECTION_LABELS, MainSectionId, normalizeMainSectionOrder } from '../mainSections';
 
 interface Props { settings: AppSettings; onSave: (s: Partial<AppSettings>) => void; onBack: () => void; }
 
+const KEY_NAME_BY_CODE: Record<string, string> = {
+  Backspace: 'Backspace',
+  Delete: 'Delete',
+  End: 'End',
+  Enter: 'Return',
+  Escape: 'Escape',
+  Home: 'Home',
+  Insert: 'Insert',
+  Minus: '-',
+  PageDown: 'PageDown',
+  PageUp: 'PageUp',
+  Space: 'Space',
+  Tab: 'Tab',
+};
+
+const KEY_NAME_BY_KEY: Record<string, string> = {
+  ArrowDown: 'Down',
+  ArrowLeft: 'Left',
+  ArrowRight: 'Right',
+  ArrowUp: 'Up',
+};
+
+function keyNameFromEvent(event: React.KeyboardEvent<HTMLInputElement>): string | null {
+  const { code, key } = event;
+  if (code.startsWith('Key') && code.length === 4) return code.slice(3);
+  if (code.startsWith('Digit') && code.length === 6) return code.slice(5);
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(code)) return code;
+  if (/^Numpad[0-9]$/.test(code)) return `num${code.slice(6)}`;
+  if (KEY_NAME_BY_CODE[code]) return KEY_NAME_BY_CODE[code];
+  if (KEY_NAME_BY_KEY[key]) return KEY_NAME_BY_KEY[key];
+  if (key.length === 1 && /^[a-z0-9]$/i.test(key)) return key.toUpperCase();
+  return null;
+}
+
+function shortcutFromEvent(event: React.KeyboardEvent<HTMLInputElement>): string | null {
+  const key = keyNameFromEvent(event);
+  if (!key || ['Control', 'Alt', 'Shift', 'Meta'].includes(event.key)) return null;
+
+  const modifiers: string[] = [];
+  if (event.ctrlKey || event.metaKey) modifiers.push('CommandOrControl');
+  if (event.altKey) modifiers.push('Alt');
+  if (event.shiftKey) modifiers.push('Shift');
+
+  if (modifiers.length === 0 && !/^F([1-9]|1[0-9]|2[0-4])$/.test(key)) return null;
+  return [...modifiers, key].join('+');
+}
+
 export default function SettingsView({ settings, onSave, onBack }: Props) {
   const C = useTheme();
-  const [s, setS] = useState({ ...settings });
+  const [s, setS] = useState({ ...settings, mainSectionOrder: normalizeMainSectionOrder(settings.mainSectionOrder) });
+  const [recordingHotkey, setRecordingHotkey] = useState(false);
   const [integrationConfigured, setIntegrationConfigured] = useState<boolean | null>(null);
   const [integrationMsg, setIntegrationMsg] = useState('');
 
@@ -39,11 +88,47 @@ export default function SettingsView({ settings, onSave, onBack }: Props) {
 
   function SectionHeader({ label }: { label: string }) {
     return (
-      <div style={{ fontSize: 10, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 0.5, padding: '10px 0 4px', borderBottom: `1px solid ${C.border}` }}>
+      <div style={{ fontSize: 11, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 0.5, padding: '10px 0 4px', borderBottom: `1px solid ${C.border}` }}>
         {label}
       </div>
     );
   }
+
+  function handleHotkeyKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.key === 'Escape') {
+      setRecordingHotkey(false);
+      event.currentTarget.blur();
+      return;
+    }
+
+    if ((event.key === 'Backspace' || event.key === 'Delete') && !event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
+      setS({ ...s, globalHotkey: '' });
+      setRecordingHotkey(false);
+      event.currentTarget.blur();
+      return;
+    }
+
+    const nextHotkey = shortcutFromEvent(event);
+    if (!nextHotkey) return;
+    setS({ ...s, globalHotkey: nextHotkey });
+    setRecordingHotkey(false);
+    event.currentTarget.blur();
+  }
+
+  function moveMainSection(id: MainSectionId, direction: -1 | 1) {
+    const order = normalizeMainSectionOrder(s.mainSectionOrder);
+    const index = order.indexOf(id);
+    const nextIndex = index + direction;
+    if (index < 0 || nextIndex < 0 || nextIndex >= order.length) return;
+    const next = [...order];
+    [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+    setS({ ...s, mainSectionOrder: next });
+  }
+
+  const mainSectionOrder = normalizeMainSectionOrder(s.mainSectionOrder);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: C.bg, color: C.text }}>
@@ -55,13 +140,13 @@ export default function SettingsView({ settings, onSave, onBack }: Props) {
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <div>
               <div style={{ fontSize: 12, color: C.text }}>Real-time data via statusLine</div>
-              <div style={{ fontSize: 10, color: C.textMuted, marginTop: 2 }}>
+              <div style={{ fontSize: 11, color: C.textMuted, marginTop: 2 }}>
                 Registers WhereMyTokens as a Claude Code plugin for live rate limits
               </div>
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
               {integrationConfigured !== null && (
-                <span style={{ fontSize: 9, color: integrationConfigured ? '#4a9a4a' : C.textMuted }}>
+                <span style={{ fontSize: 10, color: integrationConfigured ? '#4a9a4a' : C.textMuted }}>
                   {integrationConfigured ? '● Connected' : '○ Not configured'}
                 </span>
               )}
@@ -74,7 +159,7 @@ export default function SettingsView({ settings, onSave, onBack }: Props) {
             </div>
           </div>
           {integrationMsg && (
-            <div style={{ fontSize: 10, color: C.textMuted, marginTop: 4 }}>{integrationMsg}</div>
+            <div style={{ fontSize: 11, color: C.textMuted, marginTop: 4 }}>{integrationMsg}</div>
           )}
         </div>
 
@@ -84,8 +169,30 @@ export default function SettingsView({ settings, onSave, onBack }: Props) {
           <input type="checkbox" style={chk} checked={s.openAtLogin} onChange={e => setS({ ...s, openAtLogin: e.target.checked })} />
         </div>
         <div style={row}>
+          <span style={labelStyle}>Always On Top</span>
+          <input type="checkbox" style={chk} checked={s.alwaysOnTop} onChange={e => setS({ ...s, alwaysOnTop: e.target.checked })} />
+        </div>
+        <div style={row}>
           <span style={labelStyle}>Global shortcut</span>
-          <input style={{ ...inp, width: 160 }} value={s.globalHotkey} onChange={e => setS({ ...s, globalHotkey: e.target.value })} />
+          <input
+            readOnly
+            aria-label="Global shortcut"
+            title="Click, then press a shortcut. Esc cancels, Backspace clears."
+            placeholder={recordingHotkey ? 'Press shortcut...' : 'Click to record'}
+            style={{
+              ...inp,
+              width: 176,
+              cursor: 'pointer',
+              borderColor: recordingHotkey ? C.accent : C.border,
+              color: recordingHotkey ? C.accent : C.text,
+              outline: recordingHotkey ? `1px solid ${C.accent}55` : 'none',
+            }}
+            value={recordingHotkey ? '' : s.globalHotkey}
+            onFocus={() => setRecordingHotkey(true)}
+            onClick={() => setRecordingHotkey(true)}
+            onBlur={() => setRecordingHotkey(false)}
+            onKeyDown={handleHotkeyKeyDown}
+          />
         </div>
 
         <SectionHeader label="Tracking" />
@@ -133,6 +240,64 @@ export default function SettingsView({ settings, onSave, onBack }: Props) {
             <option value="tokens">5h tokens</option>
             <option value="cost">5h cost</option>
           </select>
+        </div>
+
+        <SectionHeader label="Main Layout" />
+        <div style={{ padding: '7px 0', borderBottom: `1px solid ${C.border}` }}>
+          <div style={{ display: 'grid', gap: 4 }}>
+            {mainSectionOrder.map((id, index) => (
+              <div key={id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, padding: '5px 0' }}>
+                <span style={{ fontSize: 12, color: C.textDim, minWidth: 0 }}>{MAIN_SECTION_LABELS[id]}</span>
+                <span style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+                  <button
+                    type="button"
+                    title="Move up"
+                    disabled={index === 0}
+                    onClick={() => moveMainSection(id, -1)}
+                    style={{
+                      background: C.bgRow,
+                      border: `1px solid ${C.border}`,
+                      color: index === 0 ? C.textMuted : C.textDim,
+                      opacity: index === 0 ? 0.45 : 1,
+                      cursor: index === 0 ? 'default' : 'pointer',
+                      borderRadius: 4,
+                      width: 26,
+                      height: 22,
+                      fontSize: 12,
+                    }}
+                  >
+                    ^
+                  </button>
+                  <button
+                    type="button"
+                    title="Move down"
+                    disabled={index === mainSectionOrder.length - 1}
+                    onClick={() => moveMainSection(id, 1)}
+                    style={{
+                      background: C.bgRow,
+                      border: `1px solid ${C.border}`,
+                      color: index === mainSectionOrder.length - 1 ? C.textMuted : C.textDim,
+                      opacity: index === mainSectionOrder.length - 1 ? 0.45 : 1,
+                      cursor: index === mainSectionOrder.length - 1 ? 'default' : 'pointer',
+                      borderRadius: 4,
+                      width: 26,
+                      height: 22,
+                      fontSize: 12,
+                    }}
+                  >
+                    v
+                  </button>
+                </span>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => setS({ ...s, mainSectionOrder: DEFAULT_MAIN_SECTION_ORDER })}
+            style={{ marginTop: 6, background: 'none', border: `1px solid ${C.border}`, color: C.textMuted, cursor: 'pointer', fontSize: 11, padding: '3px 8px', borderRadius: 4 }}
+          >
+            Reset order
+          </button>
         </div>
 
         <SectionHeader label="Appearance" />


### PR DESCRIPTION
## Summary

This PR adds several improvements to the app UI and settings experience, while also fixing how small usage percentages are interpreted and displayed. It now also adds an optional compact quota widget for lightweight always-on-top monitoring.

## What changed

- Added an `Always On Top` setting and applied it at runtime.
- Improved global shortcut handling so the shortcut can be recorded in settings and re-registered dynamically.
- Added customizable main-section ordering for the home screen, with a dedicated settings UI for moving sections up or down.
- Added a new **Time Gone** indicator to show how much of the current usage window has already elapsed.
- Added an optional compact widget that follows the provider and always-on-top settings.
- The compact widget shows Claude/Codex 5h and 1w usage with stacked quota/time-gone progress bars and reset timing.
- Added right-click context menus for the dashboard and widget, including refresh, settings, show/hide widget, hide dashboard, and quit actions.
- Updated the main **Plan Usage** cards to use the same stacked quota/time-gone progress style without duplicating reset time text.
- Fixed usage percentage normalization so sub-one-percent values are no longer inflated.
- Improved percentage formatting in usage cards, including clearer display for very small values.
- Applied small readability tweaks across several renderer views and components.

## Why

These changes make the desktop app easier to personalize, improve the accuracy of rate-limit visibility, and add better context for interpreting usage windows. The compact widget makes the most important quota information available without keeping the full dashboard open.

## Validation

- `npm.cmd run build`
- `npm.cmd test`
- `npm.cmd run dist`

## Screenshot
Floating Widget
<img width="576" height="263" alt="image" src="https://github.com/user-attachments/assets/b1890891-2bbc-41ce-99dd-10c9bceb68e1" />

Plan Usage vs. Time Gone
<img width="812" height="1162" alt="image" src="https://github.com/user-attachments/assets/36bb2be3-350a-4253-bb63-9da04771ce58" />

