### PR TITLE
[fix] Fix Claude usage refresh consistency

### DIFF
--- a/scripts/jsonl-summary.test.mjs
+++ b/scripts/jsonl-summary.test.mjs
@@ -14,7 +14,11 @@ function tempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'wmt-jsonl-summary-'));
 }
 
-function claudeAssistantLine({ id, timestamp, model = 'claude-sonnet-4', input = 10, output = 20, cacheCreation = 0, cacheRead = 0 }) {
+function recentIso(offsetMs = 0) {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function claudeAssistantLine({ id, timestamp = recentIso(), model = 'claude-sonnet-4', input = 10, output = 20, cacheCreation = 0, cacheRead = 0 }) {
   return JSON.stringify({
     type: 'assistant',
     timestamp,
@@ -39,7 +43,7 @@ test('streaming summary scan does not use full readFileSync for JSONL bodies', a
   cache.clearAll();
   const dir = tempDir();
   const filePath = path.join(dir, 'claude.jsonl');
-  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'a', timestamp: '2026-04-24T00:00:00.000Z' })}\n`, 'utf8');
+  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'a' })}\n`, 'utf8');
 
   const originalReadFileSync = fs.readFileSync;
   fs.readFileSync = function patchedReadFileSync(target, ...args) {
@@ -64,7 +68,7 @@ test('unchanged file reuses cached summary without reopening the stream', async 
   cache.clearAll();
   const dir = tempDir();
   const filePath = path.join(dir, 'cached.jsonl');
-  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'cache-hit', timestamp: '2026-04-24T00:00:00.000Z' })}\n`, 'utf8');
+  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'cache-hit' })}\n`, 'utf8');
 
   await scanJsonlSummaryCached(filePath, 'claude', cache, true);
 
@@ -90,10 +94,10 @@ test('Claude duplicate request updates output delta without double counting', as
   cache.clearAll();
   const dir = tempDir();
   const filePath = path.join(dir, 'duplicate.jsonl');
-  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'dup-1', timestamp: '2026-04-24T00:00:00.000Z', output: 10 })}\n`, 'utf8');
+  fs.writeFileSync(filePath, `${claudeAssistantLine({ id: 'dup-1', output: 10 })}\n`, 'utf8');
 
   await scanJsonlSummaryCached(filePath, 'claude', cache, true);
-  fs.appendFileSync(filePath, `${claudeAssistantLine({ id: 'dup-1', timestamp: '2026-04-24T00:00:01.000Z', output: 25 })}\n`, 'utf8');
+  fs.appendFileSync(filePath, `${claudeAssistantLine({ id: 'dup-1', timestamp: recentIso(1_000), output: 25 })}\n`, 'utf8');
 
   const summary = await scanJsonlSummaryCached(filePath, 'claude', cache, false);
 
@@ -107,8 +111,8 @@ test('malformed trailing JSONL text is recovered on append', async () => {
   const dir = tempDir();
   const filePath = path.join(dir, 'trailing.jsonl');
 
-  const first = claudeAssistantLine({ id: 'first', timestamp: '2026-04-24T00:00:00.000Z', output: 10 });
-  const partialPrefix = '{"type":"assistant","timestamp":"2026-04-24T00:00:01.000Z","message":{"id":"second","model":"claude-sonnet-4","usage":{"input_tokens":10';
+  const first = claudeAssistantLine({ id: 'first', output: 10 });
+  const partialPrefix = `{"type":"assistant","timestamp":"${recentIso(1_000)}","message":{"id":"second","model":"claude-sonnet-4","usage":{"input_tokens":10`;
   fs.writeFileSync(filePath, `${first}\n${partialPrefix}`, 'utf8');
 
   const firstSummary = await scanJsonlSummaryCached(filePath, 'claude', cache, true);

--- a/scripts/rate-limit-fetcher.test.mjs
+++ b/scripts/rate-limit-fetcher.test.mjs
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import https from 'node:https';
+import path from 'node:path';
 import { EventEmitter } from 'node:events';
 
 import rateLimitFetcher from '../dist/main/rateLimitFetcher.js';
@@ -10,11 +11,14 @@ const { fetchApiUsagePct, normalizeStoredApiUsagePct } = rateLimitFetcher;
 
 const originalReadFileSync = fs.readFileSync;
 const originalRequest = https.request;
+const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+let lastRequestOptions = null;
 
-function withMockCredentials() {
+function withMockCredentials(expectedPath) {
   fs.readFileSync = function patchedReadFileSync(target, ...args) {
     const filePath = String(target);
     if (filePath.endsWith('.credentials.json')) {
+      if (expectedPath) assert.equal(path.normalize(filePath), path.normalize(expectedPath));
       return JSON.stringify({
         claudeAiOauth: {
           accessToken: 'test-access-token',
@@ -37,25 +41,24 @@ function withMissingCredentials() {
   };
 }
 
-function respond(callback, statusCode, body) {
-  const res = new EventEmitter();
-  res.statusCode = statusCode;
-  callback(res);
-  process.nextTick(() => {
-    if (body) res.emit('data', body);
-    res.emit('end');
-  });
-}
-
-function withHttpResponse(statusCode, payload) {
-  https.request = function patchedRequest(_options, callback) {
+function withHttpResponse(statusCode, payload, headers = {}) {
+  https.request = function patchedRequest(options, callback) {
+    lastRequestOptions = options;
     const req = new EventEmitter();
     req.setTimeout = () => req;
     req.destroy = (error) => {
       if (error) process.nextTick(() => req.emit('error', error));
     };
     req.end = () => {
-      respond(callback, statusCode, typeof payload === 'string' ? payload : JSON.stringify(payload));
+      const res = new EventEmitter();
+      res.statusCode = statusCode;
+      res.headers = headers;
+      callback(res);
+      process.nextTick(() => {
+        const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
+        if (body) res.emit('data', body);
+        res.emit('end');
+      });
     };
     return req;
   };
@@ -64,6 +67,9 @@ function withHttpResponse(statusCode, payload) {
 function restoreMocks() {
   fs.readFileSync = originalReadFileSync;
   https.request = originalRequest;
+  lastRequestOptions = null;
+  if (originalClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
 }
 
 test.afterEach(() => {
@@ -97,7 +103,7 @@ test('Claude API marks null resets as reset-unavailable without zeroing the wind
 
 test('Claude API classifies 429 responses as rate limited', async () => {
   withMockCredentials();
-  withHttpResponse(429, { error: 'too many requests' });
+  withHttpResponse(429, { error: { message: 'too many requests. Please try again later.' } }, { 'retry-after': '180' });
 
   const result = await fetchApiUsagePct();
 
@@ -105,6 +111,24 @@ test('Claude API classifies 429 responses as rate limited', async () => {
   assert.equal(result.status.code, 'rate-limited');
   assert.equal(result.status.connected, false);
   assert.equal(result.status.httpStatus, 429);
+  assert.equal(result.status.retryAfterMs, 180_000);
+  assert.match(result.status.detail, /too many requests\./);
+  assert.doesNotMatch(result.status.detail, /Please try again later/i);
+});
+
+test('Claude API classifies 401 as an expired stored CLI token', async () => {
+  withMockCredentials();
+  withHttpResponse(401, { error: { message: 'invalid bearer token. Please try again later.' } });
+
+  const result = await fetchApiUsagePct();
+
+  assert.equal(result.usage, null);
+  assert.equal(result.status.code, 'unauthorized');
+  assert.equal(result.status.label, 'auth failed');
+  assert.equal(result.status.httpStatus, 401);
+  assert.match(result.status.detail, /Claude CLI token was rejected or expired/);
+  assert.match(result.status.detail, /invalid bearer token\./);
+  assert.doesNotMatch(result.status.detail, /Please try again later/i);
 });
 
 test('Claude API uses percentage units returned by the usage endpoint', async () => {
@@ -121,6 +145,23 @@ test('Claude API uses percentage units returned by the usage endpoint', async ()
   assert.equal(result.status.code, 'reset-unavailable');
   assert.equal(result.usage.h5Pct, 5);
   assert.equal(result.usage.weekPct, 17);
+  assert.match(String(lastRequestOptions?.headers?.['User-Agent']), /^claude-code\//);
+});
+
+test('Claude API credentials honor CLAUDE_CONFIG_DIR', async () => {
+  const configDir = path.join(process.cwd(), 'tmp-claude-config');
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  withMockCredentials(path.join(configDir, '.credentials.json'));
+  withHttpResponse(200, {
+    five_hour: { utilization: 5, resets_at: '2026-04-24T05:00:00.000Z' },
+    seven_day: { utilization: 17, resets_at: '2026-04-28T00:00:00.000Z' },
+    seven_day_sonnet: { utilization: 0, resets_at: null },
+  });
+
+  const result = await fetchApiUsagePct();
+
+  assert.ok(result.usage);
+  assert.equal(result.usage.plan, 'Max 5x');
 });
 
 test('Claude API reports schema changes when core windows are missing', async () => {

--- a/scripts/rate-limit-fetcher.test.mjs
+++ b/scripts/rate-limit-fetcher.test.mjs
@@ -107,6 +107,22 @@ test('Claude API classifies 429 responses as rate limited', async () => {
   assert.equal(result.status.httpStatus, 429);
 });
 
+test('Claude API uses percentage units returned by the usage endpoint', async () => {
+  withMockCredentials();
+  withHttpResponse(200, {
+    five_hour: { utilization: 5, resets_at: '2026-04-24T05:00:00.000Z' },
+    seven_day: { utilization: 17, resets_at: '2026-04-28T00:00:00.000Z' },
+    seven_day_sonnet: { utilization: 0, resets_at: null },
+  });
+
+  const result = await fetchApiUsagePct();
+
+  assert.ok(result.usage);
+  assert.equal(result.status.code, 'reset-unavailable');
+  assert.equal(result.usage.h5Pct, 5);
+  assert.equal(result.usage.weekPct, 17);
+});
+
 test('Claude API reports schema changes when core windows are missing', async () => {
   withMockCredentials();
   withHttpResponse(200, {
@@ -137,7 +153,7 @@ test('Claude API reports schema changes when core window fields have invalid typ
   assert.match(result.status.detail, /invalid core usage fields/i);
 });
 
-test('Claude API keeps core usage when only Sonnet window is malformed', async () => {
+test('Claude API treats utilization as percentage units when only Sonnet window is malformed', async () => {
   withMockCredentials();
   withHttpResponse(200, {
     five_hour: { utilization: 0.03, resets_at: '2026-04-24T05:00:00.000Z' },
@@ -149,10 +165,27 @@ test('Claude API keeps core usage when only Sonnet window is malformed', async (
 
   assert.ok(result.usage);
   assert.equal(result.status.code, 'reset-unavailable');
-  assert.equal(result.usage.h5Pct, 3);
-  assert.equal(result.usage.weekPct, 40);
+  assert.equal(result.usage.h5Pct, 0.03);
+  assert.equal(result.usage.weekPct, 0.4);
   assert.equal(result.usage.soPct, 0);
   assert.equal(result.usage.soResetMs, null);
+});
+
+test('Claude API does not inflate sub-one-percent usage to near full', async () => {
+  withMockCredentials();
+  withHttpResponse(200, {
+    five_hour: { utilization: 0.98, resets_at: '2026-04-24T05:00:00.000Z' },
+    seven_day: { utilization: 1.4, resets_at: '2026-04-28T00:00:00.000Z' },
+    seven_day_sonnet: { utilization: 0.2, resets_at: '2026-04-28T00:00:00.000Z' },
+  });
+
+  const result = await fetchApiUsagePct();
+
+  assert.ok(result.usage);
+  assert.equal(result.status.code, 'ok');
+  assert.equal(result.usage.h5Pct, 0.98);
+  assert.equal(result.usage.weekPct, 1.4);
+  assert.equal(result.usage.soPct, 0.2);
 });
 
 test('Claude API reports missing credentials without throwing', async () => {
@@ -185,10 +218,10 @@ test('persisted Claude API cache is normalized before reuse', () => {
   });
 
   assert.ok(normalized);
-  assert.equal(normalized.h5Pct, 63);
+  assert.equal(normalized.h5Pct, 0.63);
   assert.equal(normalized.h5ResetMs, null);
   assert.equal(normalized.weekResetMs, 1200);
-  assert.equal(normalized.extraUsage?.utilization, 100);
+  assert.equal(normalized.extraUsage?.utilization, 1);
   assert.equal(normalized.storedAt, undefined);
 });
 

--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -5,22 +5,33 @@ import path from 'node:path';
 
 import stateManagerModule from '../dist/main/stateManager.js';
 import * as jsonlCacheModule from '../dist/main/jsonlCache.js';
+import rateLimitFetcherModule from '../dist/main/rateLimitFetcher.js';
 
 const { StateManager } = stateManagerModule;
 const { JsonlCache } = jsonlCacheModule;
+const originalFetchApiUsagePct = rateLimitFetcherModule.fetchApiUsagePct;
 
 function makeStore(overrides = {}) {
   const values = { ...overrides };
-  return {
+  const store = {
     store: {},
+    values,
     get(key, fallback = null) {
       return key in values ? values[key] : fallback;
     },
     set(key, value) {
       values[key] = value;
     },
+    delete(key) {
+      delete values[key];
+    },
   };
+  return store;
 }
+
+test.afterEach(() => {
+  rateLimitFetcherModule.fetchApiUsagePct = originalFetchApiUsagePct;
+});
 
 test('cached Claude percentages with null resets expire instead of surviving forever', () => {
   const manager = new StateManager(makeStore({
@@ -321,6 +332,114 @@ test('in-memory null-reset samples also age out after later API loss', () => {
   assert.equal(limits.so.pct, 0);
 });
 
+test('expired Claude core usage snapshot clears 5h and weekly together', () => {
+  const manager = new StateManager(makeStore(), () => {});
+  manager.apiUsagePct = {
+    h5Pct: 5,
+    weekPct: 17,
+    soPct: 0,
+    h5ResetMs: 5_000,
+    weekResetMs: 6 * 24 * 60 * 60 * 1000,
+    soResetMs: null,
+    plan: 'Pro',
+    extraUsage: null,
+  };
+  manager.apiUsagePctStoredAt = Date.now() - 10_000;
+  manager.apiConnected = false;
+
+  const limits = manager.buildLimits();
+
+  assert.equal(limits.h5.pct, 0);
+  assert.equal(limits.h5.source, 'cache');
+  assert.equal(limits.week.pct, 0);
+  assert.equal(limits.week.source, 'cache');
+});
+
+test('rate-limited Claude refresh keeps the last trusted API sample without rewriting cache', async () => {
+  const store = makeStore();
+  const manager = new StateManager(store, () => {});
+  manager.apiUsagePct = {
+    h5Pct: 5,
+    weekPct: 17,
+    soPct: 0,
+    h5ResetMs: 5 * 60 * 60 * 1000,
+    weekResetMs: 6 * 24 * 60 * 60 * 1000,
+    soResetMs: null,
+    plan: 'Pro',
+    extraUsage: null,
+  };
+  manager.apiUsagePctStoredAt = Date.now() - 5_000;
+  rateLimitFetcherModule.fetchApiUsagePct = async () => ({
+    usage: null,
+    status: {
+      code: 'rate-limited',
+      connected: false,
+      label: 'rate limited',
+      detail: 'Claude API returned HTTP 429.',
+      httpStatus: 429,
+    },
+  });
+
+  await manager.refreshApiUsagePct(true);
+
+  assert.equal(manager.apiUsagePct.h5Pct, 5);
+  assert.equal(manager.apiUsagePct.weekPct, 17);
+  assert.equal(store.values._cachedApiPct, undefined);
+  assert.equal(manager.apiStatusLabel, 'rate limited');
+});
+
+test('late Claude API refresh results do not overwrite a newer generation', async () => {
+  const store = makeStore();
+  const manager = new StateManager(store, () => {});
+  let resolveFirst;
+  let resolveSecond;
+  const first = new Promise(resolve => { resolveFirst = resolve; });
+  const second = new Promise(resolve => { resolveSecond = resolve; });
+  let calls = 0;
+  rateLimitFetcherModule.fetchApiUsagePct = () => {
+    calls += 1;
+    return calls === 1 ? first : second;
+  };
+
+  const firstRefresh = manager.refreshApiUsagePct(true);
+  const secondRefresh = manager.refreshApiUsagePct(true);
+
+  resolveSecond({
+    usage: {
+      h5Pct: 5,
+      weekPct: 17,
+      soPct: 0,
+      h5ResetMs: 5 * 60 * 60 * 1000,
+      weekResetMs: 6 * 24 * 60 * 60 * 1000,
+      soResetMs: null,
+      plan: 'Pro',
+      extraUsage: null,
+    },
+    status: { code: 'ok', connected: true, label: '', detail: '' },
+  });
+  await secondRefresh;
+
+  resolveFirst({
+    usage: {
+      h5Pct: 0,
+      weekPct: 16,
+      soPct: 0,
+      h5ResetMs: null,
+      weekResetMs: 6 * 24 * 60 * 60 * 1000,
+      soResetMs: null,
+      plan: 'Pro',
+      extraUsage: null,
+    },
+    status: { code: 'ok', connected: true, label: '', detail: '' },
+  });
+  await firstRefresh;
+
+  assert.equal(manager.apiUsagePct.h5Pct, 5);
+  assert.equal(manager.apiUsagePct.weekPct, 17);
+  assert.equal(store.values._cachedApiPct.h5Pct, 5);
+  assert.equal(store.values._cachedApiPct.weekPct, 17);
+});
+
 test('persisted summary cache rejects malformed nested rollups', () => {
   const cache = new JsonlCache();
   const malformed = cache.hydratePersistedEntry({
@@ -404,6 +523,21 @@ test('visible fast refresh stays on cached session scope and logs anomalies', ()
   assert.match(source, /discoveryScope: StateManager\.SESSION_SCOPE/);
   assert.match(source, /sessionCountDelta/);
   assert.match(source, /session-count-spike/);
+});
+
+test('Claude API refresh is not committed from startup or fast-refresh follow-up paths', () => {
+  const source = fs.readFileSync(path.resolve('src', 'main', 'stateManager.ts'), 'utf8');
+  const startStart = source.indexOf('  start()');
+  const startEnd = source.indexOf('  stop()');
+  const startBody = source.slice(startStart, startEnd);
+  const fastStart = source.indexOf('private async fastRefresh');
+  const fastEnd = source.indexOf('private async refreshGitStatsAfterStartup');
+  const fastBody = source.slice(fastStart, fastEnd);
+
+  assert.doesNotMatch(startBody, /refreshApiUsagePct/);
+  assert.doesNotMatch(startBody, /Promise\.all\(\[this\.refreshAutoLimits\(\), this\.refreshApiUsagePct\(\)\]\)/);
+  assert.doesNotMatch(fastBody, /apiFollowup/);
+  assert.doesNotMatch(fastBody, /refreshApiUsagePct/);
 });
 
 test('changed session refresh merges unmatched files without falling back to scoped rebuild', () => {

--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -332,7 +332,7 @@ test('in-memory null-reset samples also age out after later API loss', () => {
   assert.equal(limits.so.pct, 0);
 });
 
-test('expired Claude core usage snapshot clears 5h and weekly together', () => {
+test('expired Claude core usage windows age independently', () => {
   const manager = new StateManager(makeStore(), () => {});
   manager.apiUsagePct = {
     h5Pct: 5,
@@ -351,8 +351,9 @@ test('expired Claude core usage snapshot clears 5h and weekly together', () => {
 
   assert.equal(limits.h5.pct, 0);
   assert.equal(limits.h5.source, 'cache');
-  assert.equal(limits.week.pct, 0);
+  assert.equal(limits.week.pct, 17);
   assert.equal(limits.week.source, 'cache');
+  assert.ok((limits.week.resetMs ?? 0) > 0);
 });
 
 test('rate-limited Claude refresh keeps the last trusted API sample without rewriting cache', async () => {
@@ -386,6 +387,67 @@ test('rate-limited Claude refresh keeps the last trusted API sample without rewr
   assert.equal(manager.apiUsagePct.weekPct, 17);
   assert.equal(store.values._cachedApiPct, undefined);
   assert.equal(manager.apiStatusLabel, 'rate limited');
+  assert.equal(manager.apiBackoffMs, 120_000);
+});
+
+test('rate-limited Claude refresh honors Retry-After before exponential backoff', async () => {
+  const manager = new StateManager(makeStore(), () => {});
+  rateLimitFetcherModule.fetchApiUsagePct = async () => ({
+    usage: null,
+    status: {
+      code: 'rate-limited',
+      connected: false,
+      label: 'rate limited',
+      detail: 'Claude API returned HTTP 429.',
+      httpStatus: 429,
+      retryAfterMs: 240_000,
+    },
+  });
+
+  await manager.refreshApiUsagePct(true);
+
+  assert.equal(manager.apiBackoffMs, 240_000);
+  assert.match(manager.apiError, /Retry in 4m/);
+});
+
+test('unauthorized Claude refresh keeps the last trusted API sample as cache', async () => {
+  const cachedSample = {
+    h5Pct: 5,
+    weekPct: 17,
+    soPct: 0,
+    h5ResetMs: 5 * 60 * 60 * 1000,
+    weekResetMs: 6 * 24 * 60 * 60 * 1000,
+    soResetMs: null,
+    plan: 'Pro',
+    extraUsage: null,
+    storedAt: Date.now() - 5_000,
+  };
+  const store = makeStore({ _cachedApiPct: cachedSample });
+  const manager = new StateManager(store, () => {});
+  manager.apiUsagePct = { ...cachedSample };
+  manager.apiUsagePctStoredAt = cachedSample.storedAt;
+  rateLimitFetcherModule.fetchApiUsagePct = async () => ({
+    usage: null,
+    status: {
+      code: 'unauthorized',
+      connected: false,
+      label: 'auth failed',
+      detail: 'Claude CLI token was rejected or expired.',
+      httpStatus: 401,
+    },
+  });
+
+  await manager.refreshApiUsagePct(true);
+  const limits = manager.buildLimits();
+
+  assert.equal(manager.apiStatusLabel, 'auth failed');
+  assert.equal(manager.apiUsagePct.h5Pct, 5);
+  assert.equal(manager.apiUsagePct.weekPct, 17);
+  assert.equal(store.values._cachedApiPct, cachedSample);
+  assert.equal(limits.h5.source, 'cache');
+  assert.equal(limits.h5.pct, 5);
+  assert.equal(limits.week.source, 'cache');
+  assert.equal(limits.week.pct, 17);
 });
 
 test('late Claude API refresh results do not overwrite a newer generation', async () => {

--- a/scripts/state-readiness.test.mjs
+++ b/scripts/state-readiness.test.mjs
@@ -64,6 +64,13 @@ test('renderer splash and session stabilization use initial readiness and daily 
   assert.match(source, /normalizeState\(next\)/);
 });
 
+test('renderer mutes cached Claude usage text while keeping the progress bar active', () => {
+  const source = fs.readFileSync(path.resolve('src', 'renderer', 'components', 'TokenStatsCard.tsx'), 'utf8');
+
+  assert.match(source, /cachedDisconnected = apiConnected === false && limitSourceLabel === 'cached'/);
+  assert.match(source, /noData \|\| cachedDisconnected \? C\.textMuted : barColor/);
+});
+
 test('startup refresh uses lightweight session bootstrapping and API status labels', () => {
   const mainSource = fs.readFileSync(path.resolve('src', 'main', 'stateManager.ts'), 'utf8');
   const rendererSource = fs.readFileSync(path.resolve('src', 'renderer', 'views', 'MainView.tsx'), 'utf8');

--- a/src/main/rateLimitFetcher.ts
+++ b/src/main/rateLimitFetcher.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as https from 'https';
 import * as path from 'path';
 import * as os from 'os';
+import { execFileSync } from 'child_process';
 
 export interface AutoLimits {
   h5: number;
@@ -56,6 +57,8 @@ export interface ClaudeApiStatus {
   label: string;
   detail: string;
   httpStatus?: number;
+  retryAfterMs?: number;
+  serverMessage?: string;
   responseKeys?: string[];
   resetFields?: {
     fiveHour: ResetFieldState;
@@ -83,19 +86,28 @@ interface UsageWindowResponse {
 class HttpResponseError extends Error {
   statusCode: number;
   body: string;
+  headers: Record<string, string | string[] | undefined>;
 
-  constructor(statusCode: number, body: string) {
+  constructor(statusCode: number, body: string, headers: Record<string, string | string[] | undefined>) {
     super(`HTTP ${statusCode}`);
     this.name = 'HttpResponseError';
     this.statusCode = statusCode;
     this.body = body;
+    this.headers = headers;
   }
+}
+
+let cachedClaudeUserAgent: string | null = null;
+
+function credentialsPath(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  return path.join(configDir && configDir.trim() ? configDir : path.join(os.homedir(), '.claude'), '.credentials.json');
 }
 
 function readCredentials(): Credentials | null {
   try {
     const raw = JSON.parse(fs.readFileSync(
-      path.join(os.homedir(), '.claude', '.credentials.json'),
+      credentialsPath(),
       'utf-8',
     )) as { claudeAiOauth?: { accessToken?: unknown; rateLimitTier?: unknown; subscriptionType?: unknown } };
     const oauth = raw.claudeAiOauth;
@@ -127,9 +139,28 @@ function logStatus(status: ClaudeApiStatus): void {
     label: status.label,
     detail: status.detail,
     httpStatus: status.httpStatus,
+    retryAfterMs: status.retryAfterMs,
+    serverMessage: status.serverMessage,
     responseKeys: status.responseKeys,
     resetFields: status.resetFields,
   });
+}
+
+function getClaudeUserAgent(): string {
+  if (cachedClaudeUserAgent !== null) return cachedClaudeUserAgent;
+  try {
+    const output = execFileSync('claude', ['--version'], {
+      encoding: 'utf8',
+      timeout: 1000,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const version = output.match(/\b(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/)?.[1];
+    cachedClaudeUserAgent = version ? `claude-code/${version}` : 'claude-code/1.0';
+  } catch {
+    cachedClaudeUserAgent = 'claude-code/1.0';
+  }
+  return cachedClaudeUserAgent;
 }
 
 function httpsGet(url: string, headers: Record<string, string>): Promise<string> {
@@ -151,7 +182,7 @@ function httpsGet(url: string, headers: Record<string, string>): Promise<string>
             resolve(body);
             return;
           }
-          reject(new HttpResponseError(statusCode, body));
+          reject(new HttpResponseError(statusCode, body, res.headers));
         });
       },
     );
@@ -260,16 +291,82 @@ function buildStatus(
   return { code, connected, label, detail, ...extras };
 }
 
+function cleanServerMessage(message: string): string {
+  return message
+    .replace(/\s*Please try again later\.?\s*$/i, '')
+    .trim();
+}
+
+function serverMessageFromBody(body: string): string | undefined {
+  const trimmed = body.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const record = asRecord(parsed);
+    if (!record) return cleanServerMessage(trimmed) || undefined;
+    const error = record.error;
+    if (typeof error === 'string') return cleanServerMessage(error) || undefined;
+    const errorRecord = asRecord(error);
+    const message = errorRecord && typeof errorRecord.message === 'string'
+      ? errorRecord.message
+      : (typeof record.message === 'string' ? record.message : '');
+    return cleanServerMessage(message) || undefined;
+  } catch {
+    return cleanServerMessage(trimmed) || undefined;
+  }
+}
+
+function withServerMessage(base: string, message: string | undefined): string {
+  return message ? `${base} ${message}` : base;
+}
+
+function retryAfterMsFromHeader(header: string | string[] | undefined, now = Date.now()): number | undefined {
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw !== 'string' || raw.trim() === '') return undefined;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds)) return Math.max(0, Math.round(seconds * 1000));
+  const timestamp = new Date(raw).getTime();
+  if (!Number.isFinite(timestamp)) return undefined;
+  return Math.max(0, timestamp - now);
+}
+
 function classifyHttpError(error: HttpResponseError): ClaudeApiStatus {
+  const serverMessage = serverMessageFromBody(error.body);
   switch (error.statusCode) {
     case 401:
-      return buildStatus('unauthorized', false, 'auth failed', 'Claude API rejected the stored access token.', { httpStatus: 401 });
+      return buildStatus(
+        'unauthorized',
+        false,
+        'auth failed',
+        withServerMessage('Claude CLI token was rejected or expired.', serverMessage),
+        { httpStatus: 401, serverMessage },
+      );
     case 403:
-      return buildStatus('forbidden', false, 'forbidden', 'Claude API denied this account or beta surface.', { httpStatus: 403 });
-    case 429:
-      return buildStatus('rate-limited', false, 'rate limited', 'Claude API returned HTTP 429.', { httpStatus: 429 });
+      return buildStatus(
+        'forbidden',
+        false,
+        'forbidden',
+        withServerMessage('Claude API denied this account or beta surface.', serverMessage),
+        { httpStatus: 403, serverMessage },
+      );
+    case 429: {
+      const retryAfterMs = retryAfterMsFromHeader(error.headers['retry-after']);
+      return buildStatus(
+        'rate-limited',
+        false,
+        'rate limited',
+        withServerMessage('Claude API returned HTTP 429.', serverMessage),
+        { httpStatus: 429, retryAfterMs, serverMessage },
+      );
+    }
     default:
-      return buildStatus('http-error', false, 'api disconnected', `Claude API returned HTTP ${error.statusCode}.`, { httpStatus: error.statusCode });
+      return buildStatus(
+        'http-error',
+        false,
+        'api disconnected',
+        withServerMessage(`Claude API returned HTTP ${error.statusCode}.`, serverMessage),
+        { httpStatus: error.statusCode, serverMessage },
+      );
   }
 }
 
@@ -358,7 +455,7 @@ export async function fetchApiUsagePct(): Promise<ApiUsageFetchResult> {
       'Content-Type': 'application/json',
       'anthropic-version': '2023-06-01',
       'anthropic-beta': 'oauth-2025-04-20',
-      'User-Agent': 'claude-code/1.0',
+      'User-Agent': getClaudeUserAgent(),
     });
 
     const parsed = JSON.parse(body) as unknown;

--- a/src/main/rateLimitFetcher.ts
+++ b/src/main/rateLimitFetcher.ts
@@ -174,9 +174,9 @@ function asUsageWindow(value: unknown): UsageWindowResponse | null {
   return record;
 }
 
-function scalePct(value: unknown): number {
+function normalizePct(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
-  return value <= 1.0 ? Math.round(value * 100) : Math.round(value);
+  return Math.max(0, Math.min(100, value));
 }
 
 function resetMs(iso: unknown, now: number): ApiResetMs {
@@ -211,13 +211,13 @@ function extraUsageSnapshot(value: unknown): ApiExtraUsage | null {
   const usedCreditsRaw = typeof record.used_credits === 'number' && Number.isFinite(record.used_credits)
     ? record.used_credits
     : (typeof record.usedCredits === 'number' && Number.isFinite(record.usedCredits) ? record.usedCredits : 0);
-  const utilizationValue = scalePct(record.utilization);
+  const utilizationValue = normalizePct(record.utilization);
   const currency = typeof record.currency === 'string' ? record.currency : null;
   return {
     isEnabled: record.is_enabled === true || record.isEnabled === true,
     monthlyLimit: Math.max(0, monthlyLimitRaw),
     usedCredits: Math.max(0, usedCreditsRaw),
-    utilization: Math.max(0, Math.min(100, utilizationValue)),
+    utilization: utilizationValue,
     currency,
   };
 }
@@ -238,9 +238,9 @@ export function normalizeStoredApiUsagePct(value: unknown): StoredApiUsagePct | 
     : undefined;
 
   return {
-    h5Pct: scalePct(record.h5Pct),
-    weekPct: scalePct(record.weekPct),
-    soPct: scalePct(record.soPct),
+    h5Pct: normalizePct(record.h5Pct),
+    weekPct: normalizePct(record.weekPct),
+    soPct: normalizePct(record.soPct),
     h5ResetMs: normalizeResetValue(record.h5ResetMs),
     weekResetMs: normalizeResetValue(record.weekResetMs),
     soResetMs: normalizeResetValue(record.soResetMs),
@@ -401,9 +401,9 @@ export async function fetchApiUsagePct(): Promise<ApiUsageFetchResult> {
       : null;
     const now = Date.now();
     const usage: ApiUsagePct = {
-      h5Pct: scalePct(fiveHour?.utilization),
-      weekPct: scalePct(sevenDay?.utilization),
-      soPct: scalePct(validSonnetWindow?.utilization),
+      h5Pct: normalizePct(fiveHour?.utilization),
+      weekPct: normalizePct(sevenDay?.utilization),
+      soPct: normalizePct(validSonnetWindow?.utilization),
       h5ResetMs: resetMs(fiveHour?.resets_at, now),
       weekResetMs: resetMs(sevenDay?.resets_at, now),
       soResetMs: resetMs(validSonnetWindow?.resets_at, now),

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -141,13 +141,18 @@ function ageCachedPct(pct: number, resetMs: number | null, elapsedMs: number): n
 }
 
 function ageApiUsageSample(sample: ApiUsagePct, elapsedMs: number): ApiUsagePct {
+  const coreWindowExpired = sample.h5ResetMs == null || sample.weekResetMs == null
+    ? elapsedMs > NULL_RESET_CACHE_TTL_MS
+    : elapsedMs > Math.min(sample.h5ResetMs, sample.weekResetMs);
+  const h5ResetMs = coreWindowExpired ? null : ageResetMs(sample.h5ResetMs, elapsedMs);
+  const weekResetMs = coreWindowExpired ? null : ageResetMs(sample.weekResetMs, elapsedMs);
   return {
     ...sample,
-    h5Pct: ageCachedPct(sample.h5Pct, sample.h5ResetMs, elapsedMs),
-    weekPct: ageCachedPct(sample.weekPct, sample.weekResetMs, elapsedMs),
+    h5Pct: coreWindowExpired ? 0 : sample.h5Pct,
+    weekPct: coreWindowExpired ? 0 : sample.weekPct,
     soPct: ageCachedPct(sample.soPct, sample.soResetMs, elapsedMs),
-    h5ResetMs: ageResetMs(sample.h5ResetMs, elapsedMs),
-    weekResetMs: ageResetMs(sample.weekResetMs, elapsedMs),
+    h5ResetMs,
+    weekResetMs,
     soResetMs: ageResetMs(sample.soResetMs, elapsedMs),
     extraUsage: sample.extraUsage ?? null,
   };
@@ -259,6 +264,7 @@ export class StateManager {
   private apiError = '';
   private lastApiCallMs = 0;
   private apiBackoffMs = 0;
+  private apiRequestSeq = 0;
   private bridgeWatcher: BridgeWatcher;
   private liveSession: LiveSessionData | null = null;
   private jsonlCache = new JsonlCache();
@@ -418,19 +424,6 @@ export class StateManager {
     this.startTimers();
     this.startWatcher();
     this.startDebugMemTimer();
-    void Promise.all([this.refreshAutoLimits(), this.refreshApiUsagePct()])
-      .then(() => {
-        const limits = this.buildLimits();
-        this.state = {
-          ...this.state,
-          limits,
-          autoLimits: this.autoLimits,
-          apiConnected: this.apiConnected,
-          apiStatusLabel: this.apiStatusLabel || undefined,
-          apiError: this.apiError || undefined,
-        };
-        this.onUpdate(this.state);
-      });
 
     this.autoLimitTimer = setInterval(() => {
       void this.refreshAutoLimits();
@@ -639,12 +632,14 @@ export class StateManager {
     };
   }
 
-  private async refreshApiUsagePct(force = false): Promise<void> {
+  private async refreshApiUsagePct(force = false): Promise<boolean> {
     const now = Date.now();
     const interval = Math.max(StateManager.API_MIN_INTERVAL_MS, this.apiBackoffMs);
-    if (!force && now - this.lastApiCallMs < interval) return;
+    if (!force && now - this.lastApiCallMs < interval) return false;
     this.lastApiCallMs = now;
+    const requestSeq = ++this.apiRequestSeq;
     const result = await fetchApiUsagePct();
+    if (requestSeq !== this.apiRequestSeq) return false;
     this.applyApiStatus(result.status);
 
     if (result.usage) {
@@ -653,15 +648,13 @@ export class StateManager {
       this.apiUsagePctStoredAt = Date.now();
       this.apiBackoffMs = 0;
       (this.store as unknown as Store<Record<string, unknown>>).set('_cachedApiPct', { ...mergedUsage, storedAt: this.apiUsagePctStoredAt });
-      return;
+      return true;
     }
 
     if (result.status.code === 'no-credentials') {
       this.apiUsagePct = null;
       this.apiUsagePctStoredAt = 0;
       (this.store as unknown as Store<Record<string, unknown>>).delete('_cachedApiPct');
-    } else {
-      this.apiUsagePct = this.getAgedApiUsagePct(now);
     }
 
     if (result.status.code === 'rate-limited') {
@@ -669,6 +662,7 @@ export class StateManager {
       this.apiError = `Claude API returned HTTP 429. Retry in ${Math.round(this.apiBackoffMs / 60000)}m.`;
       this.apiStatusLabel = 'rate limited';
     }
+    return true;
   }
 
   async forceRefresh(): Promise<void> {
@@ -1086,26 +1080,6 @@ export class StateManager {
       ...(sessionPerf ? this.perfFields('sessions', sessionPerf) : {}),
       ...(sessionResult ? this.sessionDebugExtras(sessions, sessionResult) : {}),
     });
-
-    const apiFollowupSample = this.beginPerfSample();
-    void this.refreshApiUsagePct().then(() => {
-      const refreshed = this.computeDerivedUsage(settings);
-      this.state = {
-        ...this.state,
-        usage: refreshed.usage,
-        limits: refreshed.limits,
-        apiConnected: this.apiConnected,
-        apiStatusLabel: this.apiStatusLabel || undefined,
-        apiError: this.apiError || undefined,
-        bridgeActive: refreshed.bridgeActive,
-        extraUsage: refreshed.extraUsage,
-      };
-      this.onUpdate(this.state);
-      this.logPerfTrace('fastRefresh:apiFollowup', apiFollowupSample, {
-        changedFiles: changedFiles?.size ?? 0,
-        ...(sessionResult ? this.sessionDebugExtras(this.state.sessions, sessionResult) : {}),
-      });
-    });
   }
 
   private async refreshGitStatsAfterStartup(): Promise<void> {
@@ -1148,7 +1122,7 @@ export class StateManager {
     try {
       await this.logMemorySnapshot('heavyRefresh:start');
       const apiSample = this.beginPerfSample();
-      await this.refreshApiUsagePct(force);
+      await Promise.all([this.refreshAutoLimits(), this.refreshApiUsagePct(force)]);
       apiPerf = this.finishPerfSample(apiSample);
       const initialRefreshDone = this.state.initialRefreshComplete;
       if (!force && initialRefreshDone && !this.uiVisible) {
@@ -1479,9 +1453,10 @@ export class StateManager {
       codexH5,
       codexWeek,
     };
+    const canReuseClaudeCore = canReuseClaudeCachedWindow(previous.h5) && canReuseClaudeCachedWindow(previous.week);
     return {
-      h5: canReuseClaudeCachedWindow(previous.h5) ? { ...previous.h5, source: 'cache' } : emptyUsageLimitWindow(),
-      week: canReuseClaudeCachedWindow(previous.week) ? { ...previous.week, source: 'cache' } : emptyUsageLimitWindow(),
+      h5: canReuseClaudeCore ? { ...previous.h5, source: 'cache' } : emptyUsageLimitWindow(),
+      week: canReuseClaudeCore ? { ...previous.week, source: 'cache' } : emptyUsageLimitWindow(),
       so: canReuseClaudeCachedWindow(previous.so) ? { ...previous.so, source: 'cache' } : emptyUsageLimitWindow(),
       codexH5,
       codexWeek,

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -141,15 +141,18 @@ function ageCachedPct(pct: number, resetMs: number | null, elapsedMs: number): n
 }
 
 function ageApiUsageSample(sample: ApiUsagePct, elapsedMs: number): ApiUsagePct {
-  const coreWindowExpired = sample.h5ResetMs == null || sample.weekResetMs == null
+  const h5Expired = sample.h5ResetMs == null
     ? elapsedMs > NULL_RESET_CACHE_TTL_MS
-    : elapsedMs > Math.min(sample.h5ResetMs, sample.weekResetMs);
-  const h5ResetMs = coreWindowExpired ? null : ageResetMs(sample.h5ResetMs, elapsedMs);
-  const weekResetMs = coreWindowExpired ? null : ageResetMs(sample.weekResetMs, elapsedMs);
+    : elapsedMs > sample.h5ResetMs;
+  const weekExpired = sample.weekResetMs == null
+    ? elapsedMs > NULL_RESET_CACHE_TTL_MS
+    : elapsedMs > sample.weekResetMs;
+  const h5ResetMs = h5Expired ? null : ageResetMs(sample.h5ResetMs, elapsedMs);
+  const weekResetMs = weekExpired ? null : ageResetMs(sample.weekResetMs, elapsedMs);
   return {
     ...sample,
-    h5Pct: coreWindowExpired ? 0 : sample.h5Pct,
-    weekPct: coreWindowExpired ? 0 : sample.weekPct,
+    h5Pct: h5Expired ? 0 : sample.h5Pct,
+    weekPct: weekExpired ? 0 : sample.weekPct,
     soPct: ageCachedPct(sample.soPct, sample.soResetMs, elapsedMs),
     h5ResetMs,
     weekResetMs,
@@ -658,8 +661,10 @@ export class StateManager {
     }
 
     if (result.status.code === 'rate-limited') {
-      this.apiBackoffMs = Math.min(this.apiBackoffMs === 0 ? 120_000 : this.apiBackoffMs * 2, 600_000);
-      this.apiError = `Claude API returned HTTP 429. Retry in ${Math.round(this.apiBackoffMs / 60000)}m.`;
+      this.apiBackoffMs = typeof result.status.retryAfterMs === 'number'
+        ? Math.max(0, result.status.retryAfterMs)
+        : Math.min(this.apiBackoffMs === 0 ? 120_000 : this.apiBackoffMs * 2, 600_000);
+      this.apiError = `${result.status.detail} Retry in ${Math.max(1, Math.ceil(this.apiBackoffMs / 60000))}m.`;
       this.apiStatusLabel = 'rate limited';
     }
     return true;
@@ -1453,10 +1458,9 @@ export class StateManager {
       codexH5,
       codexWeek,
     };
-    const canReuseClaudeCore = canReuseClaudeCachedWindow(previous.h5) && canReuseClaudeCachedWindow(previous.week);
     return {
-      h5: canReuseClaudeCore ? { ...previous.h5, source: 'cache' } : emptyUsageLimitWindow(),
-      week: canReuseClaudeCore ? { ...previous.week, source: 'cache' } : emptyUsageLimitWindow(),
+      h5: canReuseClaudeCachedWindow(previous.h5) ? { ...previous.h5, source: 'cache' } : emptyUsageLimitWindow(),
+      week: canReuseClaudeCachedWindow(previous.week) ? { ...previous.week, source: 'cache' } : emptyUsageLimitWindow(),
       so: canReuseClaudeCachedWindow(previous.so) ? { ...previous.so, source: 'cache' } : emptyUsageLimitWindow(),
       codexH5,
       codexWeek,

--- a/src/renderer/components/TokenStatsCard.tsx
+++ b/src/renderer/components/TokenStatsCard.tsx
@@ -89,6 +89,7 @@ function TokenStatsCard({
   const cacheTitle = cacheBadgeTitle(cacheMetricMode);
   const showSavings = stats.cacheSavingsUSD > 0.005;
   const showEta = burnRate && burnRate.h5EtaMs !== null && resetMs != null && burnRate.h5EtaMs < resetMs;
+  const cachedDisconnected = apiConnected === false && limitSourceLabel === 'cached';
   const sourceChip = limitSourceLabel ? (
     <span
       title={limitSourceLabel}
@@ -126,7 +127,7 @@ function TokenStatsCard({
         </div>
 
         {/* 대형 퍼센트 */}
-        <div style={{ fontSize: 30, fontWeight: 800, color: noData ? C.textMuted : barColor, lineHeight: 1.1, marginBottom: 6, fontFamily: C.fontMono }}>
+        <div style={{ fontSize: 30, fontWeight: 800, color: noData || cachedDisconnected ? C.textMuted : barColor, lineHeight: 1.1, marginBottom: 6, fontFamily: C.fontMono }}>
           {noData ? '—' : `${Math.round(barPct)}%`}
         </div>
 
@@ -213,7 +214,7 @@ function TokenStatsCard({
                 }} />
               )}
             </div>
-            <span style={{ fontSize: 10, fontWeight: 600, color: noData ? C.textMuted : barColor, width: 28, textAlign: 'right', flexShrink: 0, fontFamily: C.fontMono }}>
+            <span style={{ fontSize: 10, fontWeight: 600, color: noData || cachedDisconnected ? C.textMuted : barColor, width: 28, textAlign: 'right', flexShrink: 0, fontFamily: C.fontMono }}>
               {noData ? '—' : `${Math.round(barPct)}%`}
             </span>
             {!noData && resetStr && (

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -135,7 +135,7 @@ function buildHeaderStatus(args: {
     case 'local only':
       return { label: 'Local only', title: apiError || 'Claude credentials were not found. Showing local data only.', tone: 'warning' };
     case 'auth failed':
-      return { label: 'Auth failed', title: apiError || 'Claude API rejected the stored access token.', tone: 'danger' };
+      return { label: 'Auth failed', title: apiError || 'Claude CLI token was rejected or expired.', tone: 'danger' };
     case 'forbidden':
       return { label: 'Access blocked', title: apiError || 'Claude API denied this account or beta surface.', tone: 'danger' };
     case 'api disconnected':


### PR DESCRIPTION
Closes #4.

## Summary
Fixes Claude Plan Usage refresh consistency so a refresh cycle no longer exposes stale or mixed Claude API cache values such as `— / 16%` when the current Anthropic usage endpoint reports `5% / 17%`.

## Root cause
- Claude API state could be updated by more than one path: startup follow-up, heavy refresh, and fast-refresh API follow-up.
- API failures such as 429 preserved aged cache data by assigning the aged fallback back into memory.
- Claude 5h and weekly usage were aged independently, allowing an unavailable 5h window to be displayed next to a stale weekly percentage.
- The usage endpoint returns percentage units directly; scaling sub-1 values inflated low usage readings.

## Changes
- Consolidate Claude API updates into the heavy refresh cycle, with auto-limit refresh committed in the same cycle.
- Add a request generation guard so late Claude API responses cannot overwrite newer refresh results.
- Persist `_cachedApiPct` only on successful API samples; API failures keep the last trusted sample without rewriting cache.
- Treat Claude 5h and weekly core usage as one cache snapshot when aging fallback data.
- Preserve the single user-visible refresh time and rely on existing API status/source fields for partial source failures.
- Update JSONL summary tests to use recent timestamps so they do not fall out of the app's recent-entry window over time.

## Validation
- `npm.cmd test` passed: 60/60 tests.
- `npm.cmd run build` passed.