### PR TITLE
Fix Claude OAuth refresh expiry handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:main": "tsc",
     "build:renderer": "node scripts/build-renderer.mjs",
     "build": "node scripts/make-icons.mjs && npm run build:main && npm run build:renderer",
-    "test": "npm run build:main && node --test scripts/session-metadata.test.mjs scripts/git-stats-keys.test.mjs scripts/git-stats-daily.test.mjs scripts/state-readiness.test.mjs scripts/jsonl-summary.test.mjs scripts/rate-limit-fetcher.test.mjs scripts/codex-usage-fetcher.test.mjs scripts/stability-regressions.test.mjs",
+    "test": "npm run build:main && node --test scripts/session-metadata.test.mjs scripts/git-stats-keys.test.mjs scripts/git-stats-daily.test.mjs scripts/state-readiness.test.mjs scripts/jsonl-summary.test.mjs scripts/rate-limit-fetcher.test.mjs scripts/oauth-refresh.test.mjs scripts/codex-usage-fetcher.test.mjs scripts/stability-regressions.test.mjs",
     "start": "npm run build && electron .",
     "dev": "concurrently \"tsc -w\" \"wait-on dist/main/index.js && npm run build:renderer && electron .\"",
     "pack": "npm run build && electron-builder --dir",

--- a/scripts/oauth-refresh.test.mjs
+++ b/scripts/oauth-refresh.test.mjs
@@ -1,0 +1,217 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import oauthRefresh from '../dist/main/oauthRefresh.js';
+
+const {
+  refreshNow,
+  initOAuthRefresh,
+  getOAuthCredentialState,
+  __setOAuthRefreshPostForTest,
+  __clearOAuthRefreshForTest,
+} = oauthRefresh;
+
+const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+const originalDisableRefresh = process.env.WMT_DISABLE_REFRESH;
+const tempDirs = [];
+
+function makeStore(values = {}) {
+  return {
+    values,
+    get(key, fallback = null) {
+      return key in values ? values[key] : fallback;
+    },
+    set(key, value) {
+      values[key] = value;
+    },
+    delete(key) {
+      delete values[key];
+    },
+  };
+}
+
+function useTempClaudeConfig() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmt-oauth-refresh-'));
+  tempDirs.push(dir);
+  process.env.CLAUDE_CONFIG_DIR = dir;
+  return dir;
+}
+
+function credentialsPath(dir) {
+  return path.join(dir, '.credentials.json');
+}
+
+function writeCredentials(dir, oauth = {}) {
+  fs.writeFileSync(credentialsPath(dir), JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'old-access',
+      refreshToken: 'old-refresh',
+      expiresAt: Date.now() - 1000,
+      rateLimitTier: 'max_5x',
+      subscriptionType: 'max',
+      ...oauth,
+    },
+    preserved: true,
+  }, null, 2));
+}
+
+function readCredentials(dir) {
+  return JSON.parse(fs.readFileSync(credentialsPath(dir), 'utf8'));
+}
+
+test.afterEach(() => {
+  __clearOAuthRefreshForTest();
+  if (originalClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  if (originalDisableRefresh === undefined) delete process.env.WMT_DISABLE_REFRESH;
+  else process.env.WMT_DISABLE_REFRESH = originalDisableRefresh;
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('refreshNow writes rotating Claude credentials atomically', async () => {
+  const dir = useTempClaudeConfig();
+  writeCredentials(dir);
+  initOAuthRefresh(makeStore());
+  let seenUserAgent = '';
+  __setOAuthRefreshPostForTest(async (_url, params, userAgent) => {
+    seenUserAgent = userAgent;
+    assert.equal(params.grant_type, 'refresh_token');
+    assert.equal(params.refresh_token, 'old-refresh');
+    return {
+      status: 200,
+      body: JSON.stringify({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        expires_in: 3600,
+      }),
+    };
+  });
+
+  const outcome = await refreshNow('claude-code/1.0', 'test');
+  const updated = readCredentials(dir);
+
+  assert.equal(outcome.kind, 'ok');
+  assert.equal(seenUserAgent, 'claude-code/1.0');
+  assert.equal(updated.claudeAiOauth.accessToken, 'new-access');
+  assert.equal(updated.claudeAiOauth.refreshToken, 'new-refresh');
+  assert.equal(updated.claudeAiOauth.rateLimitTier, 'max_5x');
+  assert.equal(updated.preserved, true);
+  assert.ok(fs.existsSync(`${credentialsPath(dir)}.bak`));
+});
+
+test('concurrent refreshNow calls share one OAuth request', async () => {
+  const dir = useTempClaudeConfig();
+  writeCredentials(dir);
+  initOAuthRefresh(makeStore());
+  let calls = 0;
+  let resolvePost;
+  const post = new Promise(resolve => {
+    resolvePost = resolve;
+  });
+  __setOAuthRefreshPostForTest(async () => {
+    calls += 1;
+    return post;
+  });
+
+  const results = Promise.all([
+    refreshNow('claude-code/1.0', 'test'),
+    refreshNow('claude-code/1.0', 'test'),
+    refreshNow('claude-code/1.0', 'test'),
+  ]);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(calls, 1);
+  resolvePost({
+    status: 200,
+    body: JSON.stringify({
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      expires_in: 3600,
+    }),
+  });
+
+  const outcomes = await results;
+  assert.deepEqual(outcomes.map(outcome => outcome.kind), ['ok', 'ok', 'ok']);
+  assert.equal(calls, 1);
+});
+
+test('OAuth 429 cooldown is scoped to the current credential file', async () => {
+  const dir = useTempClaudeConfig();
+  writeCredentials(dir);
+  const store = makeStore();
+  initOAuthRefresh(store);
+  let calls = 0;
+  __setOAuthRefreshPostForTest(async () => {
+    calls += 1;
+    return {
+      status: 429,
+      body: JSON.stringify({ error: { message: 'Rate limited. Please try again later.' } }),
+    };
+  });
+
+  const first = await refreshNow('claude-code/1.0', 'test');
+  const second = await refreshNow('claude-code/1.0', 'test');
+
+  assert.equal(first.kind, 'rate-limited');
+  assert.equal(second.kind, 'rate-limited');
+  assert.equal(calls, 1);
+  assert.equal(store.values._oauthRefreshCooldown.reason, 'http-429');
+
+  writeCredentials(dir, {
+    accessToken: 'rotated-access',
+    refreshToken: 'rotated-refresh',
+    expiresAt: Date.now() - 1000,
+  });
+  __setOAuthRefreshPostForTest(async () => {
+    calls += 1;
+    return {
+      status: 200,
+      body: JSON.stringify({
+        access_token: 'newer-access',
+        refresh_token: 'newer-refresh',
+        expires_in: 3600,
+      }),
+    };
+  });
+
+  const third = await refreshNow('claude-code/1.0', 'test');
+
+  assert.equal(third.kind, 'ok');
+  assert.equal(calls, 2);
+  assert.equal(store.values._oauthRefreshCooldown, undefined);
+});
+
+test('refreshNow kill switch avoids OAuth network calls', async () => {
+  const dir = useTempClaudeConfig();
+  writeCredentials(dir);
+  initOAuthRefresh(makeStore());
+  process.env.WMT_DISABLE_REFRESH = '1';
+  let calls = 0;
+  __setOAuthRefreshPostForTest(async () => {
+    calls += 1;
+    return { status: 200, body: '{}' };
+  });
+
+  const outcome = await refreshNow('claude-code/1.0', 'test');
+
+  assert.equal(outcome.kind, 'rate-limited');
+  assert.equal(outcome.reason, 'kill-switch');
+  assert.equal(calls, 0);
+});
+
+test('OAuth credential state reports expiry and refresh-token presence', () => {
+  const dir = useTempClaudeConfig();
+  writeCredentials(dir, { expiresAt: Date.now() - 1000 });
+
+  const state = getOAuthCredentialState();
+
+  assert.equal(state.hasCredentials, true);
+  assert.equal(state.hasAccessToken, true);
+  assert.equal(state.hasRefreshToken, true);
+  assert.equal(state.isExpired, true);
+  assert.equal(state.shouldRefresh, true);
+});

--- a/scripts/rate-limit-fetcher.test.mjs
+++ b/scripts/rate-limit-fetcher.test.mjs
@@ -2,10 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import https from 'node:https';
+import os from 'node:os';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
 
 import rateLimitFetcher from '../dist/main/rateLimitFetcher.js';
+import oauthRefresh from '../dist/main/oauthRefresh.js';
 
 const {
   API_USAGE_CACHE_SCHEMA_VERSION,
@@ -13,13 +15,16 @@ const {
   fetchApiUsagePct,
   normalizeStoredApiUsagePct,
 } = rateLimitFetcher;
+const { __setOAuthRefreshPostForTest, __clearOAuthRefreshForTest } = oauthRefresh;
 
 const originalReadFileSync = fs.readFileSync;
 const originalRequest = https.request;
 const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+const originalDisableRefresh = process.env.WMT_DISABLE_REFRESH;
 let lastRequestOptions = null;
+const tempDirs = [];
 
-function withMockCredentials(expectedPath) {
+function withMockCredentials(expectedPath, oauthOverrides = {}) {
   fs.readFileSync = function patchedReadFileSync(target, ...args) {
     const filePath = String(target);
     if (filePath.endsWith('.credentials.json')) {
@@ -29,11 +34,29 @@ function withMockCredentials(expectedPath) {
           accessToken: 'test-access-token',
           rateLimitTier: 'max_5x',
           subscriptionType: 'max',
+          ...oauthOverrides,
         },
       });
     }
     return originalReadFileSync.call(this, target, ...args);
   };
+}
+
+function withTempClaudeCredentials(oauthOverrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmt-rate-limit-'));
+  tempDirs.push(dir);
+  process.env.CLAUDE_CONFIG_DIR = dir;
+  fs.writeFileSync(path.join(dir, '.credentials.json'), JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'test-access-token',
+      refreshToken: 'test-refresh-token',
+      expiresAt: Date.now() - 1000,
+      rateLimitTier: 'max_5x',
+      subscriptionType: 'max',
+      ...oauthOverrides,
+    },
+  }, null, 2));
+  return dir;
 }
 
 function withMissingCredentials() {
@@ -46,9 +69,11 @@ function withMissingCredentials() {
   };
 }
 
-function withHttpResponse(statusCode, payload, headers = {}) {
+function withHttpResponses(responses) {
+  const queue = [...responses];
   https.request = function patchedRequest(options, callback) {
     lastRequestOptions = options;
+    const next = queue.shift() ?? responses[responses.length - 1];
     const req = new EventEmitter();
     req.setTimeout = () => req;
     req.destroy = (error) => {
@@ -56,11 +81,11 @@ function withHttpResponse(statusCode, payload, headers = {}) {
     };
     req.end = () => {
       const res = new EventEmitter();
-      res.statusCode = statusCode;
-      res.headers = headers;
+      res.statusCode = next.statusCode;
+      res.headers = next.headers ?? {};
       callback(res);
       process.nextTick(() => {
-        const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
+        const body = typeof next.payload === 'string' ? next.payload : JSON.stringify(next.payload);
         if (body) res.emit('data', body);
         res.emit('end');
       });
@@ -69,12 +94,22 @@ function withHttpResponse(statusCode, payload, headers = {}) {
   };
 }
 
+function withHttpResponse(statusCode, payload, headers = {}) {
+  withHttpResponses([{ statusCode, payload, headers }]);
+}
+
 function restoreMocks() {
   fs.readFileSync = originalReadFileSync;
   https.request = originalRequest;
   lastRequestOptions = null;
   if (originalClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
   else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  if (originalDisableRefresh === undefined) delete process.env.WMT_DISABLE_REFRESH;
+  else process.env.WMT_DISABLE_REFRESH = originalDisableRefresh;
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  __clearOAuthRefreshForTest();
 }
 
 test.afterEach(() => {
@@ -190,6 +225,109 @@ test('Claude API classifies 401 as an expired stored CLI token', async () => {
   assert.match(result.status.detail, /Claude CLI token was rejected or expired/);
   assert.match(result.status.detail, /invalid bearer token\./);
   assert.doesNotMatch(result.status.detail, /Please try again later/i);
+});
+
+test('Claude API does not refresh a non-expired token after 401', async () => {
+  withTempClaudeCredentials({
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  });
+  let refreshCalls = 0;
+  __setOAuthRefreshPostForTest(async () => {
+    refreshCalls += 1;
+    return { status: 200, body: '{}' };
+  });
+  withHttpResponse(401, { error: { message: 'invalid bearer token. Please try again later.' } });
+
+  const result = await fetchApiUsagePct();
+
+  assert.equal(refreshCalls, 0);
+  assert.equal(result.usage, null);
+  assert.equal(result.status.code, 'unauthorized');
+  assert.equal(result.status.label, 'auth failed');
+});
+
+test('Claude API refreshes expired tokens after 401 and retries usage once', async () => {
+  withTempClaudeCredentials({
+    accessToken: 'expired-access',
+    refreshToken: 'old-refresh',
+    expiresAt: Date.now() - 1000,
+  });
+  let refreshCalls = 0;
+  let refreshUserAgent = '';
+  __setOAuthRefreshPostForTest(async (_url, params, userAgent) => {
+    refreshCalls += 1;
+    refreshUserAgent = userAgent;
+    assert.equal(params.refresh_token, 'old-refresh');
+    return {
+      status: 200,
+      body: JSON.stringify({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        expires_in: 3600,
+      }),
+    };
+  });
+  withHttpResponses([
+    { statusCode: 401, payload: { error: { message: 'invalid bearer token. Please try again later.' } } },
+    {
+      statusCode: 200,
+      payload: {
+        five_hour: { utilization: 5, resets_at: '2026-04-24T05:00:00.000Z' },
+        seven_day: { utilization: 17, resets_at: '2026-04-28T00:00:00.000Z' },
+        seven_day_sonnet: { utilization: 0, resets_at: null },
+      },
+    },
+  ]);
+
+  const result = await fetchApiUsagePct();
+
+  assert.ok(result.usage);
+  assert.equal(result.status.code, 'ok');
+  assert.equal(result.usage.h5Pct, 5);
+  assert.equal(refreshCalls, 1);
+  assert.equal(refreshUserAgent, 'claude-code/1.0');
+  assert.equal(lastRequestOptions?.headers?.Authorization, 'Bearer new-access');
+});
+
+test('Claude API reports refresh-limited when expired-token refresh gets OAuth 429', async () => {
+  withTempClaudeCredentials({
+    accessToken: 'expired-access',
+    refreshToken: 'old-refresh',
+    expiresAt: Date.now() - 1000,
+  });
+  __setOAuthRefreshPostForTest(async () => ({
+    status: 429,
+    body: JSON.stringify({ error: { message: 'Rate limited. Please try again later.' } }),
+  }));
+  withHttpResponse(401, { error: { message: 'invalid bearer token. Please try again later.' } });
+
+  const result = await fetchApiUsagePct();
+
+  assert.equal(result.usage, null);
+  assert.equal(result.status.code, 'rate-limited');
+  assert.equal(result.status.label, 'refresh limited');
+  assert.match(result.status.detail, /Claude OAuth refresh is rate limited/);
+});
+
+test('Claude API reports login-required when expired-token refresh is rejected', async () => {
+  withTempClaudeCredentials({
+    accessToken: 'expired-access',
+    refreshToken: 'old-refresh',
+    expiresAt: Date.now() - 1000,
+  });
+  __setOAuthRefreshPostForTest(async () => ({
+    status: 400,
+    body: JSON.stringify({ error: { message: 'invalid refresh token' } }),
+  }));
+  withHttpResponse(401, { error: { message: 'invalid bearer token. Please try again later.' } });
+
+  const result = await fetchApiUsagePct();
+
+  assert.equal(result.usage, null);
+  assert.equal(result.status.code, 'unauthorized');
+  assert.equal(result.status.label, 'login required');
+  assert.match(result.status.detail, /claude \/login/);
+  assert.match(result.status.detail, /invalid refresh token/);
 });
 
 test('Claude API caps huge Retry-After headers', async () => {

--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -36,7 +36,7 @@ function makeStore(overrides = {}) {
   return store;
 }
 
-function withTempClaudeCredentials() {
+function withTempClaudeCredentials(oauthOverrides = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmt-claude-test-'));
   tempClaudeDirs.push(dir);
   fs.writeFileSync(path.join(dir, '.credentials.json'), JSON.stringify({
@@ -44,9 +44,11 @@ function withTempClaudeCredentials() {
       accessToken: 'test-access-token',
       rateLimitTier: 'max_5x',
       subscriptionType: 'max',
+      ...oauthOverrides,
     },
   }));
   process.env.CLAUDE_CONFIG_DIR = dir;
+  return dir;
 }
 
 function withTempCodexAuth() {
@@ -724,6 +726,50 @@ test('forced Claude refresh does not bypass active Retry-After backoff', async (
   assert.equal(secondRefresh, false);
   assert.equal(calls, 1);
   assert.equal(manager.apiBackoffMs, 240_000);
+});
+
+test('updated Claude credentials bypass refresh-limited API backoff', async () => {
+  const dir = withTempClaudeCredentials({
+    refreshToken: 'old-refresh',
+    expiresAt: Date.now() - 1000,
+  });
+  const manager = new StateManager(makeStore(), () => {});
+  manager.consumeOAuthCredentialChange();
+  manager.apiBackoffMs = CLAUDE_API_MAX_BACKOFF_MS;
+  manager.lastApiCallMs = Date.now();
+  let calls = 0;
+  rateLimitFetcherModule.fetchApiUsagePct = async () => {
+    calls += 1;
+    return {
+      usage: {
+        h5Pct: 5,
+        weekPct: 17,
+        soPct: 0,
+        h5ResetMs: 5 * 60 * 60 * 1000,
+        weekResetMs: 6 * 24 * 60 * 60 * 1000,
+        soResetMs: null,
+        plan: 'Pro',
+        extraUsage: null,
+      },
+      status: { code: 'ok', connected: true, label: '', detail: '' },
+    };
+  };
+
+  fs.writeFileSync(path.join(dir, '.credentials.json'), JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'rotated-access',
+      refreshToken: 'rotated-refresh',
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      rateLimitTier: 'max_5x',
+      subscriptionType: 'max',
+    },
+  }));
+  const refreshed = await manager.refreshApiUsagePct(false);
+
+  assert.equal(refreshed, true);
+  assert.equal(calls, 1);
+  assert.equal(manager.apiBackoffMs, 0);
+  assert.equal(manager.apiUsagePct.h5Pct, 5);
 });
 
 test('non-rate-limited Claude failure clears stale Retry-After backoff', async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import { StateManager, AppState } from './stateManager';
 import { registerIpcHandlers, AppSettings, DEFAULT_SETTINGS, normalizeSettings } from './ipc';
 import { Notification } from 'electron';
 import { appendCrashLog, buildErrorPayload, buildQuitTrace, collectRuntimeMemorySnapshot, getCrashLogPath, getDebugMemLogPath, isDebugInstrumentationEnabled, setListenerTargetsProvider } from './debugInstrumentation';
+import { initOAuthRefresh } from './oauthRefresh';
 
 if (isDebugInstrumentationEnabled()) {
   app.commandLine.appendSwitch('js-flags', '--max-old-space-size=4096');
@@ -582,6 +583,9 @@ function markPopupMoving() {
 
 app.whenReady().then(() => {
   app.setAppUserModelId('com.wheremytokens.app');
+  initOAuthRefresh(
+    store as unknown as { get(key: string): unknown; set(key: string, value: unknown): void; delete(key: string): void },
+  );
   registerDebugTargets();
   installDebugInstrumentation();
   if (isDebugInstrumentationEnabled()) {

--- a/src/main/oauthRefresh.ts
+++ b/src/main/oauthRefresh.ts
@@ -1,0 +1,508 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+const REFRESH_TIMEOUT_MS = 8000;
+const OAUTH_REFRESH_COOLDOWN_KEY = '_oauthRefreshCooldown';
+const RATE_LIMIT_BACKOFF_LADDER_MIN = [30, 120, 360, 1440] as const;
+const KILL_SWITCH_RETRY_MS = 60 * 60 * 1000;
+
+export type RefreshOutcome =
+  | { kind: 'ok'; accessToken: string; expiresAt: number }
+  | { kind: 'invalid-grant'; serverMessage?: string }
+  | {
+      kind: 'rate-limited';
+      serverMessage?: string;
+      retryAfterMs?: number;
+      retryAt?: number;
+      reason?: OAuthRefreshCooldownReason;
+      consecutiveCount?: number;
+      serverRetryAfterMs?: number;
+    }
+  | { kind: 'network'; reason: string }
+  | { kind: 'unexpected'; status: number; body: string };
+
+export type OAuthRefreshCooldownReason = 'http-429' | 'invalid-grant' | 'kill-switch';
+
+export interface OAuthRefreshCooldown {
+  until: number;
+  reason: OAuthRefreshCooldownReason;
+  consecutiveCount: number;
+  recordedAt: number;
+  serverMessage?: string;
+  retryAfterMs?: number;
+  credentialMarker?: string;
+}
+
+export interface OAuthCredentialState {
+  hasCredentials: boolean;
+  hasAccessToken: boolean;
+  hasRefreshToken: boolean;
+  expiresAt: number | null;
+  isExpired: boolean;
+  shouldRefresh: boolean;
+  msUntilExpiry: number | null;
+}
+
+export interface OAuthCredentialFileState extends OAuthCredentialState {
+  mtimeMs: number | null;
+  size: number | null;
+}
+
+interface CredentialsFile {
+  claudeAiOauth?: {
+    accessToken?: unknown;
+    refreshToken?: unknown;
+    expiresAt?: unknown;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+type PostForm = (
+  url: string,
+  params: Record<string, string>,
+  userAgent: string,
+) => Promise<{ status: number; body: string; headers?: Record<string, string | string[] | undefined> }>;
+
+interface OAuthRefreshStore {
+  get(key: string): unknown;
+  set(key: string, value: unknown): void;
+  delete(key: string): void;
+}
+
+interface RefreshAttemptResult {
+  outcome: RefreshOutcome;
+  networkAttempted: boolean;
+  httpStatus?: number;
+}
+
+let inflight: Promise<RefreshAttemptResult> | null = null;
+let postFormImpl: PostForm = postForm;
+let refreshStore: OAuthRefreshStore | null = null;
+let memoryCooldown: OAuthRefreshCooldown | null = null;
+
+export function initOAuthRefresh(store: OAuthRefreshStore): void {
+  refreshStore = store;
+  memoryCooldown = readPersistedCooldown();
+}
+
+function credentialsPath(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  return path.join(configDir && configDir.trim() ? configDir : path.join(os.homedir(), '.claude'), '.credentials.json');
+}
+
+function readCredentialsFile(): CredentialsFile | null {
+  try {
+    return JSON.parse(fs.readFileSync(credentialsPath(), 'utf-8')) as CredentialsFile;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCredentialsAtomic(updated: CredentialsFile): void {
+  const target = credentialsPath();
+  const backup = `${target}.bak`;
+  const tmp = `${target}.tmp.${process.pid}`;
+  let fd: number | null = null;
+
+  try {
+    try {
+      fs.copyFileSync(target, backup);
+    } catch {
+      // A missing backup should not block a successful refresh write.
+    }
+
+    fd = fs.openSync(tmp, 'w', 0o600);
+    fs.writeFileSync(fd, JSON.stringify(updated, null, 2), 'utf-8');
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(tmp, target);
+  } finally {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Preserve the original failure.
+      }
+    }
+    try {
+      if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+    } catch {
+      // Best effort cleanup.
+    }
+  }
+}
+
+function killSwitchEngaged(): boolean {
+  return process.env.WMT_DISABLE_REFRESH === '1';
+}
+
+function isCooldownReason(value: unknown): value is OAuthRefreshCooldownReason {
+  return value === 'http-429' || value === 'invalid-grant' || value === 'kill-switch';
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function currentCredentialMarker(): string | null {
+  const state = getOAuthCredentialFileState();
+  if (!state.hasCredentials) return null;
+  return [
+    state.mtimeMs ?? 'no-mtime',
+    state.size ?? 'no-size',
+    state.expiresAt ?? 'no-expiry',
+    state.hasAccessToken ? 'access' : 'no-access',
+    state.hasRefreshToken ? 'refresh' : 'no-refresh',
+  ].join(':');
+}
+
+function normalizeCooldown(value: unknown): OAuthRefreshCooldown | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const until = typeof record.until === 'number' && Number.isFinite(record.until) ? record.until : null;
+  const recordedAt = typeof record.recordedAt === 'number' && Number.isFinite(record.recordedAt) ? record.recordedAt : null;
+  const rawCount = typeof record.consecutiveCount === 'number' && Number.isFinite(record.consecutiveCount)
+    ? record.consecutiveCount
+    : 0;
+  const retryAfterMs = typeof record.retryAfterMs === 'number' && Number.isFinite(record.retryAfterMs)
+    ? record.retryAfterMs
+    : undefined;
+  if (until == null || recordedAt == null || !isCooldownReason(record.reason)) return null;
+  return {
+    until,
+    reason: record.reason,
+    consecutiveCount: Math.max(0, Math.floor(rawCount)),
+    recordedAt,
+    serverMessage: typeof record.serverMessage === 'string' ? record.serverMessage : undefined,
+    retryAfterMs,
+    credentialMarker: typeof record.credentialMarker === 'string' && record.credentialMarker.length > 0
+      ? record.credentialMarker
+      : undefined,
+  };
+}
+
+function cooldownMatchesCurrentCredential(cooldown: OAuthRefreshCooldown): boolean {
+  if (!cooldown.credentialMarker) return true;
+  const credentialMarker = currentCredentialMarker();
+  return !credentialMarker || credentialMarker === cooldown.credentialMarker;
+}
+
+function readPersistedCooldown(): OAuthRefreshCooldown | null {
+  if (!refreshStore) return memoryCooldown;
+  try {
+    const normalized = normalizeCooldown(refreshStore.get(OAUTH_REFRESH_COOLDOWN_KEY));
+    if (!normalized) {
+      try {
+        refreshStore.delete(OAUTH_REFRESH_COOLDOWN_KEY);
+      } catch {
+        // Memory fallback still handles the current process.
+      }
+      return null;
+    }
+    if (!cooldownMatchesCurrentCredential(normalized)) {
+      try {
+        refreshStore.delete(OAUTH_REFRESH_COOLDOWN_KEY);
+      } catch {
+        // The current credentials should be allowed to refresh anyway.
+      }
+      return null;
+    }
+    return normalized;
+  } catch {
+    return memoryCooldown;
+  }
+}
+
+function getCooldown(): OAuthRefreshCooldown | null {
+  const cooldown = readPersistedCooldown();
+  memoryCooldown = cooldown;
+  return cooldown;
+}
+
+function setCooldown(cooldown: OAuthRefreshCooldown): void {
+  memoryCooldown = cooldown;
+  if (!refreshStore) return;
+  try {
+    refreshStore.set(OAUTH_REFRESH_COOLDOWN_KEY, cooldown);
+  } catch {
+    // Memory fallback still protects the current process.
+  }
+}
+
+function clearCooldown(): void {
+  memoryCooldown = null;
+  if (!refreshStore) return;
+  try {
+    refreshStore.delete(OAUTH_REFRESH_COOLDOWN_KEY);
+  } catch {
+    // Ignore store cleanup failures after a successful refresh.
+  }
+}
+
+function nextCooldownMs(serverRetryAfterMs: number | undefined, consecutiveCount: number): number {
+  const idx = Math.min(Math.max(0, consecutiveCount - 1), RATE_LIMIT_BACKOFF_LADDER_MIN.length - 1);
+  return Math.max(serverRetryAfterMs ?? 0, RATE_LIMIT_BACKOFF_LADDER_MIN[idx] * 60_000);
+}
+
+function rateLimitedFromCooldown(cooldown: OAuthRefreshCooldown, now: number): Extract<RefreshOutcome, { kind: 'rate-limited' }> {
+  return {
+    kind: 'rate-limited',
+    serverMessage: cooldown.serverMessage,
+    retryAfterMs: Math.max(0, cooldown.until - now),
+    retryAt: cooldown.until,
+    reason: cooldown.reason,
+    consecutiveCount: cooldown.consecutiveCount,
+    serverRetryAfterMs: cooldown.retryAfterMs,
+  };
+}
+
+function recordHttp429Cooldown(serverMessage: string | undefined, serverRetryAfterMs: number | undefined): Extract<RefreshOutcome, { kind: 'rate-limited' }> {
+  const previous = getCooldown();
+  const credentialMarker = currentCredentialMarker();
+  const sameCredential = !!credentialMarker
+    && previous?.reason === 'http-429'
+    && previous.credentialMarker === credentialMarker;
+  const consecutiveCount = sameCredential ? previous.consecutiveCount + 1 : 1;
+  const retryAfterMs = nextCooldownMs(serverRetryAfterMs, consecutiveCount);
+  const now = Date.now();
+  const cooldown: OAuthRefreshCooldown = {
+    until: now + retryAfterMs,
+    reason: 'http-429',
+    consecutiveCount,
+    recordedAt: now,
+    serverMessage,
+    retryAfterMs: serverRetryAfterMs,
+    credentialMarker: credentialMarker ?? undefined,
+  };
+  setCooldown(cooldown);
+  return {
+    kind: 'rate-limited',
+    serverMessage,
+    retryAfterMs,
+    retryAt: cooldown.until,
+    reason: 'http-429',
+    consecutiveCount,
+    serverRetryAfterMs,
+  };
+}
+
+export function getOAuthCredentialState(): OAuthCredentialState {
+  const cred = readCredentialsFile();
+  const oauth = cred?.claudeAiOauth;
+  const accessToken = oauth?.accessToken;
+  const refreshToken = oauth?.refreshToken;
+  const expiresAt = oauth?.expiresAt;
+  const hasAccessToken = typeof accessToken === 'string' && accessToken.length > 0;
+  const hasRefreshToken = typeof refreshToken === 'string' && refreshToken.length > 0;
+  const normalizedExpiresAt = typeof expiresAt === 'number' && Number.isFinite(expiresAt) ? expiresAt : null;
+  const msUntilExpiry = normalizedExpiresAt == null ? null : normalizedExpiresAt - Date.now();
+  return {
+    hasCredentials: !!cred,
+    hasAccessToken,
+    hasRefreshToken,
+    expiresAt: normalizedExpiresAt,
+    isExpired: typeof msUntilExpiry === 'number' ? msUntilExpiry <= 0 : false,
+    shouldRefresh: typeof msUntilExpiry === 'number' ? msUntilExpiry < REFRESH_LEEWAY_MS : false,
+    msUntilExpiry,
+  };
+}
+
+export function getOAuthCredentialFileState(): OAuthCredentialFileState {
+  const state = getOAuthCredentialState();
+  let mtimeMs: number | null = null;
+  let size: number | null = null;
+  try {
+    const stat = fs.statSync(credentialsPath());
+    mtimeMs = stat.mtimeMs;
+    size = stat.size;
+  } catch {
+    // Credential parsing above remains the source of truth.
+  }
+  return { ...state, mtimeMs, size };
+}
+
+export async function refreshNow(userAgent: string, _trigger = 'unknown'): Promise<RefreshOutcome> {
+  const now = Date.now();
+  const cooldownBefore = getCooldown();
+  if (killSwitchEngaged()) {
+    return {
+      kind: 'rate-limited',
+      serverMessage: 'disabled by WMT_DISABLE_REFRESH',
+      retryAfterMs: KILL_SWITCH_RETRY_MS,
+      retryAt: now + KILL_SWITCH_RETRY_MS,
+      reason: 'kill-switch',
+      consecutiveCount: cooldownBefore?.consecutiveCount ?? 0,
+    };
+  }
+  if (cooldownBefore && now < cooldownBefore.until) {
+    return rateLimitedFromCooldown(cooldownBefore, now);
+  }
+  if (inflight) {
+    const joined = await inflight;
+    return joined.outcome;
+  }
+  inflight = doRefresh(userAgent).finally(() => {
+    inflight = null;
+  });
+  const result = await inflight;
+  return result.outcome;
+}
+
+async function doRefresh(userAgent: string): Promise<RefreshAttemptResult> {
+  const cred = readCredentialsFile();
+  const oauth = cred?.claudeAiOauth;
+  const refreshToken = oauth?.refreshToken;
+  if (!cred || !oauth || typeof refreshToken !== 'string' || refreshToken.length === 0) {
+    return { outcome: { kind: 'invalid-grant' }, networkAttempted: false };
+  }
+
+  let resp: { status: number; body: string; headers?: Record<string, string | string[] | undefined> };
+  try {
+    resp = await postFormImpl(TOKEN_URL, {
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    }, userAgent);
+  } catch (error) {
+    return { outcome: { kind: 'network', reason: String((error as Error)?.message ?? error) }, networkAttempted: true };
+  }
+
+  if (resp.status === 400 || resp.status === 401) {
+    return {
+      outcome: { kind: 'invalid-grant', serverMessage: refreshErrorMessage(resp.body) },
+      networkAttempted: true,
+      httpStatus: resp.status,
+    };
+  }
+
+  if (resp.status === 429) {
+    return {
+      outcome: recordHttp429Cooldown(refreshErrorMessage(resp.body), retryAfterMsFromHeader(resp.headers?.['retry-after'])),
+      networkAttempted: true,
+      httpStatus: resp.status,
+    };
+  }
+
+  if (resp.status < 200 || resp.status >= 300) {
+    return {
+      outcome: { kind: 'unexpected', status: resp.status, body: resp.body.slice(0, 500) },
+      networkAttempted: true,
+      httpStatus: resp.status,
+    };
+  }
+
+  let parsed: { access_token?: unknown; refresh_token?: unknown; expires_in?: unknown };
+  try {
+    parsed = JSON.parse(resp.body) as typeof parsed;
+  } catch {
+    return {
+      outcome: { kind: 'unexpected', status: resp.status, body: resp.body.slice(0, 500) },
+      networkAttempted: true,
+      httpStatus: resp.status,
+    };
+  }
+
+  if (typeof parsed.access_token !== 'string' || typeof parsed.expires_in !== 'number' || !Number.isFinite(parsed.expires_in)) {
+    return {
+      outcome: { kind: 'unexpected', status: resp.status, body: resp.body.slice(0, 500) },
+      networkAttempted: true,
+      httpStatus: resp.status,
+    };
+  }
+
+  const expiresAt = Date.now() + parsed.expires_in * 1000;
+  const updated: CredentialsFile = {
+    ...cred,
+    claudeAiOauth: {
+      ...oauth,
+      accessToken: parsed.access_token,
+      refreshToken: typeof parsed.refresh_token === 'string' && parsed.refresh_token.length > 0
+        ? parsed.refresh_token
+        : refreshToken,
+      expiresAt,
+    },
+  };
+  writeCredentialsAtomic(updated);
+  clearCooldown();
+
+  return { outcome: { kind: 'ok', accessToken: parsed.access_token, expiresAt }, networkAttempted: true, httpStatus: resp.status };
+}
+
+function refreshErrorMessage(body: string): string | undefined {
+  const trimmed = body.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const record = asRecord(parsed);
+    if (!record) return trimmed.slice(0, 500);
+    if (typeof record.error === 'string') return record.error;
+    const error = asRecord(record.error);
+    if (error && typeof error.message === 'string') return error.message;
+    if (typeof record.message === 'string') return record.message;
+  } catch {
+    return trimmed.slice(0, 500);
+  }
+  return undefined;
+}
+
+function retryAfterMsFromHeader(header: string | string[] | undefined): number | undefined {
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw !== 'string' || raw.trim() === '') return undefined;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds)) return Math.max(0, Math.round(seconds * 1000));
+  const timestamp = new Date(raw).getTime();
+  if (!Number.isFinite(timestamp)) return undefined;
+  return Math.max(0, timestamp - Date.now());
+}
+
+async function postForm(
+  url: string,
+  params: Record<string, string>,
+  userAgent: string,
+): Promise<{ status: number; body: string; headers?: Record<string, string | string[] | undefined> }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        'User-Agent': userAgent,
+      },
+      body: new URLSearchParams(params),
+      signal: controller.signal,
+    });
+    const headers: Record<string, string | undefined> = {};
+    res.headers.forEach((value, key) => {
+      headers[key.toLowerCase()] = value;
+    });
+    return { status: res.status, body: await res.text(), headers };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') throw new Error('timeout');
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function __setOAuthRefreshPostForTest(impl: PostForm | null): void {
+  postFormImpl = impl ?? postForm;
+  inflight = null;
+}
+
+export function __clearOAuthRefreshForTest(): void {
+  postFormImpl = postForm;
+  inflight = null;
+  clearCooldown();
+  refreshStore = null;
+  memoryCooldown = null;
+}

--- a/src/main/rateLimitFetcher.ts
+++ b/src/main/rateLimitFetcher.ts
@@ -2,11 +2,13 @@ import * as fs from 'fs';
 import * as https from 'https';
 import * as path from 'path';
 import * as os from 'os';
+import { getOAuthCredentialState, refreshNow, RefreshOutcome } from './oauthRefresh';
 
 export const API_USAGE_CACHE_SCHEMA_VERSION = 2;
 export const CLAUDE_API_MAX_BACKOFF_MS = 600_000;
 
 const CLAUDE_USER_AGENT = 'claude-code/1.0';
+const CLAUDE_OAUTH_REFRESH_USER_AGENT = 'claude-code/1.0';
 const MAX_SERVER_MESSAGE_LENGTH = 240;
 const MAX_CLAUDE_API_RESPONSE_BYTES = 256 * 1024;
 
@@ -461,6 +463,107 @@ function limitsFromTier(tier: string, sub: string): AutoLimits {
   return { h5: 100, week: 500, sonnetWeek: 100_000_000, plan: sub || tier || 'Unknown', source: 'default' };
 }
 
+async function performUsageFetch(cred: Credentials): Promise<ApiUsageFetchResult> {
+  const body = await httpsGet('https://api.anthropic.com/api/oauth/usage', {
+    Authorization: `Bearer ${cred.accessToken}`,
+    'Content-Type': 'application/json',
+    'anthropic-version': '2023-06-01',
+    'anthropic-beta': 'oauth-2025-04-20',
+    'User-Agent': CLAUDE_USER_AGENT,
+  });
+
+  const parsed = JSON.parse(body) as unknown;
+  const data = asRecord(parsed);
+  if (!data) {
+    const status = buildStatus('schema-changed', false, 'schema changed', 'Claude API returned a non-object response.');
+    logStatus(status);
+    return { usage: null, status };
+  }
+
+  const fiveHour = asUsageWindow(data.five_hour);
+  const sevenDay = asUsageWindow(data.seven_day);
+  const sevenDaySonnet = asUsageWindow(data.seven_day_sonnet);
+  const responseKeys = Object.keys(data).sort();
+  const resetFields = {
+    fiveHour: resetFieldState(fiveHour),
+    sevenDay: resetFieldState(sevenDay),
+    sevenDaySonnet: resetFieldState(sevenDaySonnet),
+  } satisfies NonNullable<ClaudeApiStatus['resetFields']>;
+
+  if (!fiveHour || !sevenDay) {
+    const status = missingCoreWindowStatus(responseKeys, resetFields);
+    logStatus(status);
+    return { usage: null, status };
+  }
+
+  const invalidCoreFields: string[] = [];
+  if (!hasValidUtilization(fiveHour)) invalidCoreFields.push('five_hour.utilization');
+  if (!hasValidUtilization(sevenDay)) invalidCoreFields.push('seven_day.utilization');
+  if (!hasValidResetField(fiveHour)) invalidCoreFields.push('five_hour.resets_at');
+  if (!hasValidResetField(sevenDay)) invalidCoreFields.push('seven_day.resets_at');
+  if (invalidCoreFields.length > 0) {
+    const status = invalidCoreWindowStatus(responseKeys, resetFields, invalidCoreFields);
+    logStatus(status);
+    return { usage: null, status };
+  }
+
+  const validSonnetWindow = sevenDaySonnet && hasValidUtilization(sevenDaySonnet) && hasValidResetField(sevenDaySonnet)
+    ? sevenDaySonnet
+    : null;
+  const now = Date.now();
+  const usage: ApiUsagePct = {
+    h5Pct: normalizePct(fiveHour?.utilization),
+    weekPct: normalizePct(sevenDay?.utilization),
+    soPct: normalizePct(validSonnetWindow?.utilization),
+    h5ResetMs: resetMs(fiveHour?.resets_at, now),
+    weekResetMs: resetMs(sevenDay?.resets_at, now),
+    soResetMs: resetMs(validSonnetWindow?.resets_at, now),
+    plan: planFromTier(cred.rateLimitTier, cred.subscriptionType),
+    extraUsage: extraUsageSnapshot(data.extra_usage),
+  };
+
+  const coreUnknownResetFields = [
+    resetFields.fiveHour === 'null' ? 'five_hour' : null,
+    resetFields.sevenDay === 'null' ? 'seven_day' : null,
+  ].filter((field): field is string => !!field);
+  const optionalUnknownResetFields = [
+    resetFields.sevenDaySonnet !== 'present' || (sevenDaySonnet && !validSonnetWindow) ? 'seven_day_sonnet' : null,
+  ].filter((field): field is string => !!field);
+
+  const status = coreUnknownResetFields.length > 0
+    ? buildStatus(
+        'reset-unavailable',
+        true,
+        'reset partial',
+        `${coreUnknownResetFields.join(', ')} reset is unavailable.`,
+        { responseKeys, resetFields },
+      )
+    : buildStatus('ok', true, optionalUnknownResetFields.length > 0 ? 'sonnet reset unavailable' : '', '', { responseKeys, resetFields });
+
+  logStatus(status);
+  return { usage, status };
+}
+
+function loginRequiredStatus(message?: string): ClaudeApiStatus {
+  return buildStatus(
+    'unauthorized',
+    false,
+    'login required',
+    withServerMessage('Refresh token rejected. Run `claude /login` to re-authenticate.', message),
+    { httpStatus: 401, serverMessage: message },
+  );
+}
+
+function refreshRateLimitedStatus(outcome: Extract<RefreshOutcome, { kind: 'rate-limited' }>): ClaudeApiStatus {
+  return buildStatus(
+    'rate-limited',
+    false,
+    'refresh limited',
+    withServerMessage('Claude OAuth refresh is rate limited.', outcome.serverMessage),
+    { httpStatus: 429, retryAfterMs: outcome.retryAfterMs, serverMessage: outcome.serverMessage },
+  );
+}
+
 export async function fetchApiUsagePct(): Promise<ApiUsageFetchResult> {
   const cred = readCredentials();
   if (!cred) {
@@ -470,85 +573,39 @@ export async function fetchApiUsagePct(): Promise<ApiUsageFetchResult> {
   }
 
   try {
-    const body = await httpsGet('https://api.anthropic.com/api/oauth/usage', {
-      Authorization: `Bearer ${cred.accessToken}`,
-      'Content-Type': 'application/json',
-      'anthropic-version': '2023-06-01',
-      'anthropic-beta': 'oauth-2025-04-20',
-      'User-Agent': CLAUDE_USER_AGENT,
-    });
-
-    const parsed = JSON.parse(body) as unknown;
-    const data = asRecord(parsed);
-    if (!data) {
-      const status = buildStatus('schema-changed', false, 'schema changed', 'Claude API returned a non-object response.');
-      logStatus(status);
-      return { usage: null, status };
-    }
-
-    const fiveHour = asUsageWindow(data.five_hour);
-    const sevenDay = asUsageWindow(data.seven_day);
-    const sevenDaySonnet = asUsageWindow(data.seven_day_sonnet);
-    const responseKeys = Object.keys(data).sort();
-    const resetFields = {
-      fiveHour: resetFieldState(fiveHour),
-      sevenDay: resetFieldState(sevenDay),
-      sevenDaySonnet: resetFieldState(sevenDaySonnet),
-    } satisfies NonNullable<ClaudeApiStatus['resetFields']>;
-
-    if (!fiveHour || !sevenDay) {
-      const status = missingCoreWindowStatus(responseKeys, resetFields);
-      logStatus(status);
-      return { usage: null, status };
-    }
-
-    const invalidCoreFields: string[] = [];
-    if (!hasValidUtilization(fiveHour)) invalidCoreFields.push('five_hour.utilization');
-    if (!hasValidUtilization(sevenDay)) invalidCoreFields.push('seven_day.utilization');
-    if (!hasValidResetField(fiveHour)) invalidCoreFields.push('five_hour.resets_at');
-    if (!hasValidResetField(sevenDay)) invalidCoreFields.push('seven_day.resets_at');
-    if (invalidCoreFields.length > 0) {
-      const status = invalidCoreWindowStatus(responseKeys, resetFields, invalidCoreFields);
-      logStatus(status);
-      return { usage: null, status };
-    }
-
-    const validSonnetWindow = sevenDaySonnet && hasValidUtilization(sevenDaySonnet) && hasValidResetField(sevenDaySonnet)
-      ? sevenDaySonnet
-      : null;
-    const now = Date.now();
-    const usage: ApiUsagePct = {
-      h5Pct: normalizePct(fiveHour?.utilization),
-      weekPct: normalizePct(sevenDay?.utilization),
-      soPct: normalizePct(validSonnetWindow?.utilization),
-      h5ResetMs: resetMs(fiveHour?.resets_at, now),
-      weekResetMs: resetMs(sevenDay?.resets_at, now),
-      soResetMs: resetMs(validSonnetWindow?.resets_at, now),
-      plan: planFromTier(cred.rateLimitTier, cred.subscriptionType),
-      extraUsage: extraUsageSnapshot(data.extra_usage),
-    };
-
-    const coreUnknownResetFields = [
-      resetFields.fiveHour === 'null' ? 'five_hour' : null,
-      resetFields.sevenDay === 'null' ? 'seven_day' : null,
-    ].filter((field): field is string => !!field);
-    const optionalUnknownResetFields = [
-      resetFields.sevenDaySonnet !== 'present' || (sevenDaySonnet && !validSonnetWindow) ? 'seven_day_sonnet' : null,
-    ].filter((field): field is string => !!field);
-
-    const status = coreUnknownResetFields.length > 0
-      ? buildStatus(
-          'reset-unavailable',
-          true,
-          'reset partial',
-          `${coreUnknownResetFields.join(', ')} reset is unavailable.`,
-          { responseKeys, resetFields },
-        )
-      : buildStatus('ok', true, optionalUnknownResetFields.length > 0 ? 'sonnet reset unavailable' : '', '', { responseKeys, resetFields });
-
-    logStatus(status);
-    return { usage, status };
+    return await performUsageFetch(cred);
   } catch (error) {
+    if (error instanceof HttpResponseError && error.statusCode === 401) {
+      const state = getOAuthCredentialState();
+      const looksLikeExpiredToken = state.isExpired || (state.msUntilExpiry != null && state.msUntilExpiry < 60_000);
+      if (!looksLikeExpiredToken) {
+        const status = classifyHttpError(error);
+        logStatus(status);
+        return { usage: null, status };
+      }
+
+      const outcome = await refreshNow(CLAUDE_OAUTH_REFRESH_USER_AGENT, '401-retry');
+      if (outcome.kind === 'ok') {
+        try {
+          return await performUsageFetch({ ...cred, accessToken: outcome.accessToken });
+        } catch (retryError) {
+          const status = classifyRuntimeError(retryError);
+          logStatus(status);
+          return { usage: null, status };
+        }
+      }
+      if (outcome.kind === 'invalid-grant') {
+        const status = loginRequiredStatus(outcome.serverMessage ?? serverMessageFromBody(error.body));
+        logStatus(status);
+        return { usage: null, status };
+      }
+      if (outcome.kind === 'rate-limited') {
+        const status = refreshRateLimitedStatus(outcome);
+        logStatus(status);
+        return { usage: null, status };
+      }
+    }
+
     const status = classifyRuntimeError(error);
     logStatus(status);
     return { usage: null, status };

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -18,6 +18,7 @@ import { normalizeGitCwdKey, normalizeGitPathKey, preferGitStats, repoKeyFromGit
 import { ActivityBreakdown, ActivityBreakdownKind, CodexRateLimitWindow, FileUsageSummary, SessionSnapshot } from './jsonlTypes';
 import { CodexAccountState, readCodexAccountState } from './codexAccount';
 import { appendDebugMemoryLog, collectRuntimeMemorySnapshot, isDebugInstrumentationEnabled } from './debugInstrumentation';
+import { getOAuthCredentialFileState } from './oauthRefresh';
 
 export interface SessionInfo extends DiscoveredSession {
   modelName: string;
@@ -297,6 +298,7 @@ export class StateManager {
   private lastApiCallMs = 0;
   private apiBackoffMs = 0;
   private apiRequestSeq = 0;
+  private lastOAuthCredentialMarker: string | null = null;
   private codexUsagePct: CodexUsagePct | null = null;
   private codexUsagePctStoredAt = 0;
   private codexUsageConnected = false;
@@ -690,11 +692,29 @@ export class StateManager {
     };
   }
 
+  private consumeOAuthCredentialChange(): boolean {
+    const state = getOAuthCredentialFileState();
+    const marker = state.hasCredentials
+      ? [
+          state.mtimeMs ?? 'no-mtime',
+          state.size ?? 'no-size',
+          state.expiresAt ?? 'no-expiry',
+          state.hasAccessToken ? 'access' : 'no-access',
+          state.hasRefreshToken ? 'refresh' : 'no-refresh',
+        ].join(':')
+      : 'missing';
+    const changed = this.lastOAuthCredentialMarker !== null && this.lastOAuthCredentialMarker !== marker;
+    this.lastOAuthCredentialMarker = marker;
+    return changed;
+  }
+
   private async refreshApiUsagePct(force = false): Promise<boolean> {
     const now = Date.now();
+    const credentialsChanged = this.consumeOAuthCredentialChange();
+    if (credentialsChanged) this.apiBackoffMs = 0;
     const elapsedSinceLastApiCall = now - this.lastApiCallMs;
-    if (this.apiBackoffMs > 0 && elapsedSinceLastApiCall < this.apiBackoffMs) return false;
-    if (!force && elapsedSinceLastApiCall < StateManager.API_MIN_INTERVAL_MS) return false;
+    if (!credentialsChanged && this.apiBackoffMs > 0 && elapsedSinceLastApiCall < this.apiBackoffMs) return false;
+    if (!force && !credentialsChanged && elapsedSinceLastApiCall < StateManager.API_MIN_INTERVAL_MS) return false;
     this.lastApiCallMs = now;
     const requestSeq = ++this.apiRequestSeq;
     const result = await fetchApiUsagePct();
@@ -725,7 +745,7 @@ export class StateManager {
         ? Math.min(CLAUDE_API_MAX_BACKOFF_MS, Math.max(0, result.status.retryAfterMs))
         : Math.min(this.apiBackoffMs === 0 ? 120_000 : this.apiBackoffMs * 2, CLAUDE_API_MAX_BACKOFF_MS);
       this.apiError = `${result.status.detail} Retry in ${Math.max(1, Math.ceil(this.apiBackoffMs / 60000))}m.`;
-      this.apiStatusLabel = 'rate limited';
+      this.apiStatusLabel = result.status.label || 'rate limited';
     } else {
       this.apiBackoffMs = 0;
     }

--- a/src/renderer/views/CompactWidgetView.tsx
+++ b/src/renderer/views/CompactWidgetView.tsx
@@ -163,11 +163,14 @@ function providerHealth(
     switch (claudeStatusLabel) {
       case 'rate limited':
         return { key: 'claude', label: 'Claude limited', tone: 'warning', title: 'Claude API is rate limited; cached or bridge data may be used.' };
+      case 'refresh limited':
+        return { key: 'claude', label: 'Claude refresh', tone: 'warning', title: 'Claude OAuth refresh is rate limited; cached or bridge data may be used.' };
       case 'reset partial':
         return { key: 'claude', label: 'Claude partial', tone: 'warning', title: 'Claude usage loaded, but reset timing is unavailable.' };
       case 'local only':
         return { key: 'claude', label: 'Claude local', tone: 'warning', title: 'Claude credentials are unavailable, so local data is being used.' };
       case 'auth failed':
+      case 'login required':
       case 'forbidden':
       case 'api disconnected':
         return { key: 'claude', label: 'Claude offline', tone: 'danger', title: 'Claude API is unavailable.' };

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -155,6 +155,8 @@ function buildHeaderStatus(args: {
   switch (apiStatusLabel) {
     case 'rate limited':
       return { label: 'Claude limited', title: apiError || 'Claude API returned HTTP 429.', tone: 'warning' };
+    case 'refresh limited':
+      return { label: 'Claude refresh', title: apiError || 'Claude OAuth refresh is rate limited.', tone: 'warning' };
     case 'schema changed':
       return { label: 'Claude schema', title: apiError || 'Claude API response changed shape.', tone: 'danger' };
     case 'reset partial':
@@ -163,6 +165,8 @@ function buildHeaderStatus(args: {
       return { label: 'Claude local', title: apiError || 'Claude credentials were not found. Showing local data only.', tone: 'warning' };
     case 'auth failed':
       return { label: 'Claude auth', title: apiError || 'Claude CLI token was rejected or expired.', tone: 'danger' };
+    case 'login required':
+      return { label: 'Claude login', title: apiError || 'Refresh token rejected. Run `claude /login` to re-authenticate.', tone: 'danger' };
     case 'forbidden':
       return { label: 'Claude blocked', title: apiError || 'Claude API denied this account or beta surface.', tone: 'danger' };
     case 'api disconnected':


### PR DESCRIPTION
After three days of testing, I found a reliable way to refresh the Claude OAuth token without requiring Claude Code CLI to be running.

This is especially useful for users who mainly use Claude Desktop instead of Claude Code CLI. With this fix, WhereMyTokens refreshes the Claude OAuth token only after the usage API reports an expired access token, then retries the usage request with the new access token.

The key finding is that the OAuth refresh request needs to use a fixed User-Agent:

`claude-code/1.0`

Using the real/versioned Claude Code User-Agent, such as `claude-code/2.1.133`, consistently led to 429 responses in my tests.

This PR supersedes #9. That PR was closed/unmerged and had conflicts because it was based on an older fork branch. This branch was recreated from the current upstream `main` and reapplies only the production OAuth refresh logic while preserving the newer Codex usage, cache schema, compact widget, and reset handling changes already on upstream.

## Summary

- Add passive Claude OAuth refresh after expired-token usage API 401 responses.
- Retry `/api/oauth/usage` once after a successful refresh and write rotated credentials back atomically.
- Use singleflight refresh plus credential-scoped OAuth 429 cooldowns so stale cooldowns are ignored after credentials rotate.
- Preserve the last trusted Claude API usage sample on auth/refresh failures.
- Surface `refresh limited` and `login required` statuses without adding temporary diagnostic UI or refresh-history logs.

## Validation

- `npm.cmd test` passed: 109/109 tests.
- `npm.cmd run build` passed.
- `npm.cmd run dist` passed and produced `release/WhereMyTokens Setup 1.13.2.exe` and `release/WhereMyTokens 1.13.2.exe`.