### PR TITLE
feat: add waiting animation toggle

### DIFF
--- a/scripts/state-readiness.test.mjs
+++ b/scripts/state-readiness.test.mjs
@@ -121,6 +121,9 @@ test('settings and widget integration guard malformed persisted values', () => {
   assert.match(ipcSource, /function normalizedSettingsPartial\(partial: unknown\)/);
   assert.match(ipcSource, /typeof record\.globalHotkey === 'string'/);
   assert.match(ipcSource, /typeof record\.compactWidgetEnabled === 'boolean'/);
+  assert.match(ipcSource, /compactWidgetWaitingAnimationEnabled: boolean/);
+  assert.match(ipcSource, /typeof record\.compactWidgetWaitingAnimationEnabled === 'boolean'/);
+  assert.match(ipcSource, /compactWidgetWaitingAnimationEnabled: false/);
   assert.match(ipcSource, /return \[\.\.\.new Set\(thresholds\)\]\.sort/);
   assert.match(ipcSource, /hasOwnProperty\.call\(record, 'compactWidgetBounds'\)/);
   assert.match(ipcSource, /normalizeSettings\(store\.store\)/);
@@ -143,6 +146,7 @@ test('settings and widget integration guard malformed persisted values', () => {
   assert.match(mainSource, /widgetWindow\.setAlwaysOnTop\(true\)/);
   assert.match(appSource, /handleToggleCompactWidget/);
   assert.match(appSource, /compactWidgetEnabled: !state\.settings\.compactWidgetEnabled/);
+  assert.match(appSource, /compactWidgetWaitingAnimationEnabled: next\.settings\?\.compactWidgetWaitingAnimationEnabled === true/);
   assert.match(mainViewSource, /PictureInPicture2/);
   assert.match(mainViewSource, /aria-pressed=\{compactWidgetEnabled\}/);
   assert.match(mainViewSource, /Show floating Quota Pace widget/);
@@ -154,10 +158,14 @@ test('settings and widget integration guard malformed persisted values', () => {
   assert.match(widgetSource, /dragSeqRef/);
   assert.match(widgetSource, /dragSeq !== dragSeqRef\.current/);
   assert.match(widgetSource, /const toolbarButtonStyle: React\.CSSProperties/);
+  assert.match(widgetSource, /animateWaiting=\{state\.settings\.compactWidgetWaitingAnimationEnabled === true\}/);
+  assert.match(widgetSource, /visualState === 'waiting' && !animateWaiting/);
   assert.match(widgetSource, /return `\$\{hours\}h \$\{minutes\}m`/);
   assert.match(widgetSource, /gridTemplateColumns: '24px minmax\(0, 1fr\) 38px 64px'/);
   assert.match(sectionsSource, /Array\.isArray\(value\) \? value : \[\]/);
   assert.match(settingsSource, /buildSettingsPatch\(s, baseSettings, latestSettings\)/);
+  assert.match(settingsSource, /compactWidgetWaitingAnimationEnabled/);
+  assert.match(settingsSource, /Waiting animation/);
   assert.match(settingsSource, /if \(sameSettingValue\(currentValue, settingValue\(latest, key\)\)\) continue/);
   assert.match(settingsSource, /Use Ctrl\+Shift or Ctrl\+Alt/);
 });

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -37,6 +37,7 @@ export interface AppSettings {
   hiddenProjects: string[];
   excludedProjects: string[];
   compactWidgetEnabled: boolean;
+  compactWidgetWaitingAnimationEnabled: boolean;
   compactWidgetBounds: CompactWidgetBounds | null;
   theme: 'auto' | 'light' | 'dark';
 }
@@ -126,6 +127,7 @@ function normalizedSettingsPartial(partial: unknown): Partial<AppSettings> {
   const excludedProjects = stringArray(record.excludedProjects);
   if (excludedProjects) next.excludedProjects = excludedProjects;
   if (typeof record.compactWidgetEnabled === 'boolean') next.compactWidgetEnabled = record.compactWidgetEnabled;
+  if (typeof record.compactWidgetWaitingAnimationEnabled === 'boolean') next.compactWidgetWaitingAnimationEnabled = record.compactWidgetWaitingAnimationEnabled;
   if (Object.prototype.hasOwnProperty.call(record, 'compactWidgetBounds')) {
     const compactWidgetBounds = normalizeCompactWidgetBounds(record.compactWidgetBounds);
     if (compactWidgetBounds !== undefined) next.compactWidgetBounds = compactWidgetBounds;
@@ -161,6 +163,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   hiddenProjects: [],
   excludedProjects: [],
   compactWidgetEnabled: false,
+  compactWidgetWaitingAnimationEnabled: false,
   compactWidgetBounds: null,
   theme: 'auto',
 };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -52,7 +52,7 @@ const DEFAULT_STATE: AppState = {
     trayDisplay: 'h5pct', theme: 'auto',
     mainSectionOrder: DEFAULT_MAIN_SECTION_ORDER,
     hiddenProjects: [], excludedProjects: [],
-    compactWidgetEnabled: false, compactWidgetBounds: null,
+    compactWidgetEnabled: false, compactWidgetWaitingAnimationEnabled: false, compactWidgetBounds: null,
   },
   autoLimits: null,
   codexAccount: { serviceTier: null },
@@ -192,6 +192,7 @@ function normalizeState(next: AppState): AppState {
       hiddenProjects: arrayOrEmpty(next.settings?.hiddenProjects),
       excludedProjects: arrayOrEmpty(next.settings?.excludedProjects),
       compactWidgetEnabled: next.settings?.compactWidgetEnabled === true,
+      compactWidgetWaitingAnimationEnabled: next.settings?.compactWidgetWaitingAnimationEnabled === true,
       compactWidgetBounds: next.settings?.compactWidgetBounds
         && typeof next.settings.compactWidgetBounds.x === 'number'
         && typeof next.settings.compactWidgetBounds.y === 'number'

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -165,6 +165,7 @@ export interface AppSettings {
   hiddenProjects: string[];
   excludedProjects: string[];
   compactWidgetEnabled: boolean;
+  compactWidgetWaitingAnimationEnabled: boolean;
   compactWidgetBounds: { x: number; y: number } | null;
   theme: 'auto' | 'light' | 'dark';
 }

--- a/src/renderer/views/CompactWidgetView.tsx
+++ b/src/renderer/views/CompactWidgetView.tsx
@@ -124,7 +124,7 @@ function missingLimitStatus(
   return {};
 }
 
-function MiniLimitStatus({ state }: { state: 'syncing' | 'waiting' }) {
+function MiniLimitStatus({ state, animate = true }: { state: 'syncing' | 'waiting'; animate?: boolean }) {
   const C = useTheme();
   const label = state === 'syncing' ? 'syncing' : 'waiting';
   return (
@@ -134,7 +134,15 @@ function MiniLimitStatus({ state }: { state: 'syncing' | 'waiting' }) {
           <span
             key={index}
             className="wmt-sync-dot"
-            style={{ width: 3, height: 3, background: state === 'syncing' ? C.accent : C.textMuted, animationDelay: `${index * 0.16}s` }}
+            style={{
+              width: 3,
+              height: 3,
+              background: state === 'syncing' ? C.accent : C.textMuted,
+              animation: animate ? undefined : 'none',
+              animationDelay: animate ? `${index * 0.16}s` : undefined,
+              opacity: animate ? undefined : 0.55,
+              transform: animate ? undefined : 'scale(0.85)',
+            }}
           />
         ))}
       </span>
@@ -223,6 +231,7 @@ function ProgressRow({
   unknownLabel = 'loading',
   unknownBadge = 'wait',
   unknownTitle,
+  animateWaiting = false,
 }: {
   label: string;
   quotaPct: number;
@@ -234,10 +243,12 @@ function ProgressRow({
   unknownLabel?: string;
   unknownBadge?: string;
   unknownTitle?: string;
+  animateWaiting?: boolean;
 }) {
   const C = useTheme();
   const quota = clampPct(quotaPct);
   const visualState: 'syncing' | 'waiting' | null = pending ? 'syncing' : unknown ? (unknownLabel === 'loading' ? 'syncing' : 'waiting') : null;
+  const suppressWaitingAnimation = visualState === 'waiting' && !animateWaiting;
   const elapsed = visualState ? null : timeElapsedPct(label, resetMs);
   const elapsedWidth = elapsed ?? 0;
   const resetLabel = pending ? '' : unknown ? unknownBadge : formatResetShort(resetMs);
@@ -287,6 +298,8 @@ function ProgressRow({
               background: visualState === 'syncing'
                 ? `linear-gradient(90deg, transparent, ${C.accent}88, transparent)`
                 : `linear-gradient(90deg, transparent, ${C.textMuted}55, transparent)`,
+              animation: suppressWaitingAnimation ? 'none' : undefined,
+              opacity: suppressWaitingAnimation ? 0.32 : undefined,
             }}
           />
         ) : null}
@@ -310,7 +323,7 @@ function ProgressRow({
         style={{ textAlign: 'right', color: C.textDim, fontSize: 10, fontFamily: C.fontMono, whiteSpace: 'nowrap' }}
       >
         {visualState ? (
-          <MiniLimitStatus state={visualState} />
+          <MiniLimitStatus state={visualState} animate={!suppressWaitingAnimation} />
         ) : (
           <>
             <span style={{ color: paceColor }}>{formatPct(quota)}</span>
@@ -323,7 +336,7 @@ function ProgressRow({
   );
 }
 
-function AgentBlock({ agent }: { agent: WidgetAgent }) {
+function AgentBlock({ agent, animateWaiting }: { agent: WidgetAgent; animateWaiting: boolean }) {
   const C = useTheme();
   return (
     <div style={{ display: 'grid', gap: 5 }}>
@@ -364,6 +377,7 @@ function AgentBlock({ agent }: { agent: WidgetAgent }) {
             unknownLabel={row.unknownLabel}
             unknownBadge={row.unknownBadge}
             unknownTitle={row.unknownTitle}
+            animateWaiting={animateWaiting}
           />
         ))}
       </div>
@@ -591,7 +605,7 @@ export default function CompactWidgetView({ state, onRefresh }: Props) {
       </div>
 
       <div style={{ display: 'grid', gap: agents.length > 1 ? 9 : 6 }}>
-        {agents.map(agent => <AgentBlock key={agent.key} agent={agent} />)}
+        {agents.map(agent => <AgentBlock key={agent.key} agent={agent} animateWaiting={state.settings.compactWidgetWaitingAnimationEnabled === true} />)}
       </div>
       {healthItems.length > 0 ? (
         <div

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -78,6 +78,7 @@ const EDITABLE_SETTING_KEYS: EditableSettingKey[] = [
   'hiddenProjects',
   'excludedProjects',
   'compactWidgetEnabled',
+  'compactWidgetWaitingAnimationEnabled',
   'theme',
 ];
 
@@ -297,6 +298,15 @@ export default function SettingsView({ settings, onSave, onBack }: Props) {
             </div>
           </div>
           <input type="checkbox" style={chk} checked={s.compactWidgetEnabled} onChange={e => setS({ ...s, compactWidgetEnabled: e.target.checked })} />
+        </div>
+        <div style={row}>
+          <div>
+            <div style={labelStyle}>Waiting animation</div>
+            <div style={{ fontSize: 10, color: C.textMuted, marginTop: 2 }}>
+              Animates floating-widget waiting bars when limit data is missing
+            </div>
+          </div>
+          <input type="checkbox" style={chk} checked={s.compactWidgetWaitingAnimationEnabled} onChange={e => setS({ ...s, compactWidgetWaitingAnimationEnabled: e.target.checked })} />
         </div>
         <div style={row}>
           <span style={labelStyle}>Global shortcut</span>


### PR DESCRIPTION
Add a `compactWidgetWaitingAnimationEnabled` setting to avoid interruption of user attention.

﻿## Summary
- Add a persisted `compactWidgetWaitingAnimationEnabled` setting, defaulting to off.
- Expose a Settings toggle for floating-widget waiting animations.
- Suppress the compact widget `waiting` bar/dot animation by default while keeping `syncing` animated.

## Validation
- `npm.cmd run build`
- `npm.cmd test` (118/118 passing; run outside the sandbox because the suite writes Electron Store cache under AppData)

## Notes
- `release-reset-fix/` remains untracked and is excluded from this PR. Its remaining `app.asar` is locked by the current Codex process.
