### PR TITLE
Keep hotkey popup responsive

### DIFF
--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -1082,12 +1082,16 @@ test('popup show starts with recent watcher and promotes wide watcher later', ()
   const watcherStart = source.indexOf('  private startWatcher');
   const watcherEnd = source.indexOf('  private async fastRefresh', watcherStart);
   const watcherBody = source.slice(watcherStart, watcherEnd);
+  const promotionStart = source.indexOf('  private scheduleWideWatcherPromotion');
+  const promotionEnd = source.indexOf('  private isPerfDebugEnabled', promotionStart);
+  const promotionBody = source.slice(promotionStart, promotionEnd);
 
   assert.match(visibleBody, /this\.startWatcher\('popup:show:recent', 'recent'\)/);
   assert.match(visibleBody, /this\.scheduleWideWatcherPromotion\(\)/);
   assert.match(watcherBody, /mode: WatcherMode = 'auto'/);
   assert.match(watcherBody, /const useWideWatcher = mode === 'wide' \|\| \(mode === 'auto' && this\.uiVisible\)/);
   assert.match(source, /this\.startWatcher\('popup:show:wide', 'wide'\)/);
+  assert.match(promotionBody, /this\.scheduleForegroundRefresh\(\)/);
 });
 
 test('foreground refresh uses a scan budget while force refresh remains full', () => {
@@ -1105,10 +1109,17 @@ test('foreground refresh uses a scan budget while force refresh remains full', (
   assert.match(scheduleBody, /this\.heavyRefresh\(false, false, StateManager\.FOREGROUND_SCAN_BUDGET_MS\)/);
   assert.match(source, /FOREGROUND_WARMUP_DELAY_MS = 3_000/);
   assert.match(heavyBody, /scanBudgetMs: number \| null = null/);
+  assert.match(heavyBody, /allowHiddenFullScan = false/);
+  assert.match(heavyBody, /!allowHiddenFullScan && initialRefreshDone && !this\.uiVisible/);
   assert.match(heavyBody, /const effectiveScanBudgetMs = scanBudgetMs \?\? /);
   assert.match(heavyBody, /const partialHistoryScan = effectiveScanBudgetMs !== null && loaded\.partial/);
+  assert.match(heavyBody, /const nextSummaries = partialHistoryScan && initialRefreshDone/);
+  assert.match(heavyBody, /new Map\(\[\.\.\.this\.summaries, \.\.\.loaded\.summaries\]\)/);
+  assert.match(heavyBody, /this\.mergeCodexRateLimits\(this\.codexRateLimits, loaded\.codexRateLimits \?\? undefined\)/);
   assert.match(heavyBody, /const showHistoryWarmupBanner = allowStartupBudget && !initialRefreshDone && loaded\.partial/);
-  assert.match(heavyBody, /this\.scheduleHistoryWarmup\(showHistoryWarmupBanner \? StateManager\.STARTUP_WARMUP_DELAY_MS : StateManager\.FOREGROUND_WARMUP_DELAY_MS\)/);
+  assert.match(heavyBody, /this\.scheduleHistoryWarmup\(/);
+  assert.match(heavyBody, /showHistoryWarmupBanner \? StateManager\.STARTUP_WARMUP_DELAY_MS : StateManager\.FOREGROUND_WARMUP_DELAY_MS/);
+  assert.match(heavyBody, /true,\s*\)/);
   assert.match(heavyBody, /historyWarmupPending: showHistoryWarmupBanner/);
   assert.match(heavyBody, /historyWarmupStartsAt: showHistoryWarmupBanner \? historyWarmupStartsAt : null/);
   assert.doesNotMatch(heavyBody, /historyWarmupPending: partialHistoryScan/);

--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -1073,3 +1073,39 @@ test('cached session refresh prunes retained sessions back to the recent-active 
   assert.match(refreshBody, /this\.retainScopedSessionInfos\(next\)/);
   assert.match(refreshBody, /this\.retainScopedSessionInfos\(this\.state\.sessions\)/);
 });
+
+test('popup show starts with recent watcher and promotes wide watcher later', () => {
+  const source = fs.readFileSync(path.resolve('src', 'main', 'stateManager.ts'), 'utf8');
+  const visibleStart = source.indexOf('  setUiVisible(visible: boolean): void');
+  const visibleEnd = source.indexOf('  private clearForegroundTimers', visibleStart);
+  const visibleBody = source.slice(visibleStart, visibleEnd);
+  const watcherStart = source.indexOf('  private startWatcher');
+  const watcherEnd = source.indexOf('  private async fastRefresh', watcherStart);
+  const watcherBody = source.slice(watcherStart, watcherEnd);
+
+  assert.match(visibleBody, /this\.startWatcher\('popup:show:recent', 'recent'\)/);
+  assert.match(visibleBody, /this\.scheduleWideWatcherPromotion\(\)/);
+  assert.match(watcherBody, /mode: WatcherMode = 'auto'/);
+  assert.match(watcherBody, /const useWideWatcher = mode === 'wide' \|\| \(mode === 'auto' && this\.uiVisible\)/);
+  assert.match(source, /this\.startWatcher\('popup:show:wide', 'wide'\)/);
+});
+
+test('foreground refresh uses a scan budget while force refresh remains full', () => {
+  const source = fs.readFileSync(path.resolve('src', 'main', 'stateManager.ts'), 'utf8');
+  const scheduleStart = source.indexOf('  private scheduleForegroundRefresh');
+  const scheduleEnd = source.indexOf('  private scheduleWideWatcherPromotion', scheduleStart);
+  const scheduleBody = source.slice(scheduleStart, scheduleEnd);
+  const forceStart = source.indexOf('  async forceRefresh');
+  const forceEnd = source.indexOf('  private startTimers', forceStart);
+  const forceBody = source.slice(forceStart, forceEnd);
+  const heavyStart = source.indexOf('  private async heavyRefresh');
+  const heavyEnd = source.indexOf('  private buildStartupPriorityFiles', heavyStart);
+  const heavyBody = source.slice(heavyStart, heavyEnd);
+
+  assert.match(scheduleBody, /this\.heavyRefresh\(false, false, StateManager\.FOREGROUND_SCAN_BUDGET_MS\)/);
+  assert.match(heavyBody, /scanBudgetMs: number \| null = null/);
+  assert.match(heavyBody, /const effectiveScanBudgetMs = scanBudgetMs \?\? /);
+  assert.match(heavyBody, /historyWarmupPending: partialHistoryScan/);
+  assert.match(forceBody, /await this\.heavyRefresh\(true\)/);
+  assert.doesNotMatch(forceBody, /FOREGROUND_SCAN_BUDGET_MS/);
+});

--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -1103,10 +1103,12 @@ test('foreground refresh uses a scan budget while force refresh remains full', (
   const heavyBody = source.slice(heavyStart, heavyEnd);
 
   assert.match(scheduleBody, /this\.heavyRefresh\(false, false, StateManager\.FOREGROUND_SCAN_BUDGET_MS\)/);
+  assert.match(source, /FOREGROUND_WARMUP_DELAY_MS = 3_000/);
   assert.match(heavyBody, /scanBudgetMs: number \| null = null/);
   assert.match(heavyBody, /const effectiveScanBudgetMs = scanBudgetMs \?\? /);
   assert.match(heavyBody, /const partialHistoryScan = effectiveScanBudgetMs !== null && loaded\.partial/);
   assert.match(heavyBody, /const showHistoryWarmupBanner = allowStartupBudget && !initialRefreshDone && loaded\.partial/);
+  assert.match(heavyBody, /this\.scheduleHistoryWarmup\(showHistoryWarmupBanner \? StateManager\.STARTUP_WARMUP_DELAY_MS : StateManager\.FOREGROUND_WARMUP_DELAY_MS\)/);
   assert.match(heavyBody, /historyWarmupPending: showHistoryWarmupBanner/);
   assert.match(heavyBody, /historyWarmupStartsAt: showHistoryWarmupBanner \? historyWarmupStartsAt : null/);
   assert.doesNotMatch(heavyBody, /historyWarmupPending: partialHistoryScan/);

--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -1105,7 +1105,11 @@ test('foreground refresh uses a scan budget while force refresh remains full', (
   assert.match(scheduleBody, /this\.heavyRefresh\(false, false, StateManager\.FOREGROUND_SCAN_BUDGET_MS\)/);
   assert.match(heavyBody, /scanBudgetMs: number \| null = null/);
   assert.match(heavyBody, /const effectiveScanBudgetMs = scanBudgetMs \?\? /);
-  assert.match(heavyBody, /historyWarmupPending: partialHistoryScan/);
+  assert.match(heavyBody, /const partialHistoryScan = effectiveScanBudgetMs !== null && loaded\.partial/);
+  assert.match(heavyBody, /const showHistoryWarmupBanner = allowStartupBudget && !initialRefreshDone && loaded\.partial/);
+  assert.match(heavyBody, /historyWarmupPending: showHistoryWarmupBanner/);
+  assert.match(heavyBody, /historyWarmupStartsAt: showHistoryWarmupBanner \? historyWarmupStartsAt : null/);
+  assert.doesNotMatch(heavyBody, /historyWarmupPending: partialHistoryScan/);
   assert.match(forceBody, /await this\.heavyRefresh\(true\)/);
   assert.doesNotMatch(forceBody, /FOREGROUND_SCAN_BUDGET_MS/);
 });

--- a/scripts/state-readiness.test.mjs
+++ b/scripts/state-readiness.test.mjs
@@ -106,7 +106,7 @@ test('warmup mode marks Codex local-log limits as provisional and defers alerts'
   assert.match(mainSource, /historyWarmupPending \|\|/);
   assert.match(alertSource, /deferCodexLocalLog/);
   assert.match(alertSource, /key\.startsWith\('codex-'\) && source === 'localLog'/);
-  assert.match(stateSource, /deferCodexLocalLog: startupPartial/);
+  assert.match(stateSource, /deferCodexLocalLog: partialHistoryScan/);
 });
 
 test('settings and widget integration guard malformed persisted values', () => {
@@ -168,6 +168,31 @@ test('settings and widget integration guard malformed persisted values', () => {
   assert.match(settingsSource, /Waiting animation/);
   assert.match(settingsSource, /if \(sameSettingValue\(currentValue, settingValue\(latest, key\)\)\) continue/);
   assert.match(settingsSource, /Use Ctrl\+Shift or Ctrl\+Alt/);
+});
+
+test('popup show path sends cached state without forcing refresh', () => {
+  const mainSource = fs.readFileSync(path.resolve('src', 'main', 'index.ts'), 'utf8');
+  const showStart = mainSource.indexOf('function showPopup');
+  const showEnd = mainSource.indexOf('function sendWidgetStateUpdate', showStart);
+  const showBody = mainSource.slice(showStart, showEnd);
+
+  assert.match(showBody, /popupWindow\.show\(\)/);
+  assert.match(showBody, /popupWindow\.webContents\.send\('state:updated', currentState\)/);
+  assert.doesNotMatch(showBody, /forceRefresh\(/);
+  assert.doesNotMatch(showBody, /heavyRefresh\(/);
+  assert.doesNotMatch(showBody, /await /);
+});
+
+test('visible UI transition schedules refresh instead of running heavy refresh inline', () => {
+  const stateSource = fs.readFileSync(path.resolve('src', 'main', 'stateManager.ts'), 'utf8');
+  const visibleStart = stateSource.indexOf('  setUiVisible(visible: boolean): void');
+  const visibleEnd = stateSource.indexOf('  private clearForegroundTimers', visibleStart);
+  const visibleBody = stateSource.slice(visibleStart, visibleEnd);
+
+  assert.match(visibleBody, /this\.scheduleForegroundRefresh\(\)/);
+  assert.match(visibleBody, /this\.scheduleWideWatcherPromotion\(\)/);
+  assert.doesNotMatch(visibleBody, /void this\.heavyRefresh\(/);
+  assert.doesNotMatch(visibleBody, /this\.heavyRefresh\(/);
 });
 
 test('Codex account limit collection is separated from visible usage filters', () => {

--- a/scripts/state-readiness.test.mjs
+++ b/scripts/state-readiness.test.mjs
@@ -223,7 +223,7 @@ test('startup refresh uses lightweight session bootstrapping and API status labe
   const mainSource = fs.readFileSync(path.resolve('src', 'main', 'stateManager.ts'), 'utf8');
   const rendererSource = fs.readFileSync(path.resolve('src', 'renderer', 'views', 'MainView.tsx'), 'utf8');
 
-  assert.match(mainSource, /buildScopedSessionInfosDetailed\(loaded\.summaries\)/);
+  assert.match(mainSource, /buildScopedSessionInfosDetailed\(nextSummaries\)/);
   assert.match(mainSource, /buildStartupPriorityFiles/);
   assert.match(mainSource, /historyWarmupStartsAt/);
   assert.match(rendererSource, /apiStatusLabel/);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -374,13 +374,13 @@ function resolvePopupBounds(trayBounds: Electron.Rectangle): Electron.Rectangle 
 function showPopup(view: AppView = 'main') {
   if (!popupWindow || popupWindow.isDestroyed()) popupWindow = createPopupWindow();
   if (!tray) return;
+  const currentState = stateManager?.getState();
   syncCompactWidget();
 
   popupWindow.setBounds(resolvePopupBounds(tray.getBounds()));
   popupWindow.show();
   popupWindow.focus();
   sendPopupNavigation(view);
-  const currentState = stateManager?.getState();
   if (currentState) {
     pendingStateUpdate = null;
     if (stateUpdateTimer) clearTimeout(stateUpdateTimer);

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -100,6 +100,7 @@ export interface AppState {
 }
 
 type WatcherProfile = 'wide' | 'recent' | 'off';
+type WatcherMode = 'auto' | 'wide' | 'recent';
 
 interface PerfSampleStart {
   wallNs: bigint;
@@ -316,6 +317,8 @@ export class StateManager {
   private heavyPending = false;
   private historyWarmupTimer: NodeJS.Timeout | null = null;
   private gitWarmupTimer: NodeJS.Timeout | null = null;
+  private foregroundRefreshTimer: NodeJS.Timeout | null = null;
+  private wideWatcherPromotionTimer: NodeJS.Timeout | null = null;
   private debugMemTimer: NodeJS.Timeout | null = null;
   private uiBusy = false;
   private uiVisible = false;
@@ -330,6 +333,9 @@ export class StateManager {
   private static readonly FAST_REFRESH_HIDDEN_MS = 300_000;
   private static readonly HEAVY_REFRESH_HIDDEN_MS = 900_000;
   private static readonly STARTUP_SCAN_BUDGET_MS = 2_500;
+  private static readonly FOREGROUND_REFRESH_DELAY_MS = 750;
+  private static readonly FOREGROUND_SCAN_BUDGET_MS = 2_500;
+  private static readonly WIDE_WATCHER_PROMOTION_DELAY_MS = 5_000;
   private static readonly STARTUP_WARMUP_DELAY_MS = 30_000;
   private static readonly STARTUP_GIT_DELAY_MS = 60_000;
   private static readonly STARTUP_CLAUDE_FILE_LIMIT = 48;
@@ -522,6 +528,10 @@ export class StateManager {
     if (this.fastDebounce) clearTimeout(this.fastDebounce);
     if (this.historyWarmupTimer) clearTimeout(this.historyWarmupTimer);
     if (this.gitWarmupTimer) clearTimeout(this.gitWarmupTimer);
+    if (this.foregroundRefreshTimer) clearTimeout(this.foregroundRefreshTimer);
+    if (this.wideWatcherPromotionTimer) clearTimeout(this.wideWatcherPromotionTimer);
+    this.foregroundRefreshTimer = null;
+    this.wideWatcherPromotionTimer = null;
     this.watcher?.close();
     this.bridgeWatcher.stop();
     this.jsonlCache.flushPersisted();
@@ -545,10 +555,45 @@ export class StateManager {
     if (this.uiVisible === visible) return;
     this.uiVisible = visible;
     this.startTimers();
-    this.startWatcher(visible ? 'popup:show' : 'popup:hide');
-    if (visible && this.state.initialRefreshComplete && !this.uiBusy) {
-      void this.heavyRefresh();
+    if (visible) {
+      this.startWatcher('popup:show:recent', 'recent');
+      if (this.state.initialRefreshComplete) {
+        this.scheduleForegroundRefresh();
+        this.scheduleWideWatcherPromotion();
+      }
+      return;
     }
+    this.clearForegroundTimers();
+    this.startWatcher('popup:hide', 'recent');
+  }
+
+  private clearForegroundTimers(): void {
+    if (this.foregroundRefreshTimer) clearTimeout(this.foregroundRefreshTimer);
+    if (this.wideWatcherPromotionTimer) clearTimeout(this.wideWatcherPromotionTimer);
+    this.foregroundRefreshTimer = null;
+    this.wideWatcherPromotionTimer = null;
+  }
+
+  private scheduleForegroundRefresh(): void {
+    if (this.foregroundRefreshTimer) clearTimeout(this.foregroundRefreshTimer);
+    this.foregroundRefreshTimer = setTimeout(() => {
+      this.foregroundRefreshTimer = null;
+      if (!this.uiVisible) return;
+      if (this.uiBusy) {
+        this.scheduleForegroundRefresh();
+        return;
+      }
+      void this.heavyRefresh(false, false, StateManager.FOREGROUND_SCAN_BUDGET_MS);
+    }, StateManager.FOREGROUND_REFRESH_DELAY_MS);
+  }
+
+  private scheduleWideWatcherPromotion(): void {
+    if (this.wideWatcherPromotionTimer) clearTimeout(this.wideWatcherPromotionTimer);
+    this.wideWatcherPromotionTimer = setTimeout(() => {
+      this.wideWatcherPromotionTimer = null;
+      if (!this.uiVisible) return;
+      this.startWatcher('popup:show:wide', 'wide');
+    }, StateManager.WIDE_WATCHER_PROMOTION_DELAY_MS);
   }
 
   private isPerfDebugEnabled(): boolean {
@@ -1141,14 +1186,15 @@ export class StateManager {
     return targets;
   }
 
-  private startWatcher(reason = 'refresh') {
+  private startWatcher(reason = 'refresh', mode: WatcherMode = 'auto') {
     this.watcher?.close();
     this.watcher = null;
 
     const provider = this.getSettings().provider ?? 'both';
     const watchTargets: string[] = [];
+    const useWideWatcher = mode === 'wide' || (mode === 'auto' && this.uiVisible);
 
-    if (this.uiVisible) {
+    if (useWideWatcher) {
       if ((provider === 'claude' || provider === 'both') && fs.existsSync(SESSIONS_DIR)) {
         watchTargets.push(SESSIONS_DIR);
       }
@@ -1265,7 +1311,7 @@ export class StateManager {
     this.onUpdate(this.state);
   }
 
-  private async heavyRefresh(force = false, allowStartupBudget = false) {
+  private async heavyRefresh(force = false, allowStartupBudget = false, scanBudgetMs: number | null = null) {
     const totalPerf = this.beginPerfSample();
     let apiPerf: PerfMetrics | null = null;
     let loadPerf: PerfMetrics | null = null;
@@ -1292,6 +1338,7 @@ export class StateManager {
       ]);
       apiPerf = this.finishPerfSample(apiSample);
       const initialRefreshDone = this.state.initialRefreshComplete;
+      const effectiveScanBudgetMs = scanBudgetMs ?? (allowStartupBudget && !initialRefreshDone ? StateManager.STARTUP_SCAN_BUDGET_MS : null);
       if (!force && initialRefreshDone && !this.uiVisible) {
         const sessionSample = this.beginPerfSample();
         const settings = this.getSettings();
@@ -1333,10 +1380,7 @@ export class StateManager {
         return;
       }
       const loadSample = this.beginPerfSample();
-      const loaded = await this.loadProviderSummaries(
-        force,
-        allowStartupBudget && !initialRefreshDone ? StateManager.STARTUP_SCAN_BUDGET_MS : null,
-      );
+      const loaded = await this.loadProviderSummaries(force, effectiveScanBudgetMs);
       loadPerf = this.finishPerfSample(loadSample);
       this.jsonlCache.flushPersisted();
       this.summaries = loaded.summaries;
@@ -1345,13 +1389,13 @@ export class StateManager {
       const settings = this.getSettings();
       const derived = this.computeDerivedUsage(settings);
       const codexAccount = readCodexAccountState();
-      const startupPartial = allowStartupBudget && !initialRefreshDone && loaded.partial;
-      const historyWarmupStartsAt = startupPartial
+      const partialHistoryScan = effectiveScanBudgetMs !== null && loaded.partial;
+      const historyWarmupStartsAt = partialHistoryScan
         ? this.scheduleHistoryWarmup()
         : null;
-      if (!startupPartial) this.clearHistoryWarmup();
+      if (!partialHistoryScan) this.clearHistoryWarmup();
       const sessionBuildSample = this.beginPerfSample();
-      sessionResult = startupPartial
+      sessionResult = partialHistoryScan
         ? this.buildScopedSessionInfosDetailed(loaded.summaries)
         : this.buildScopedSessionInfosDetailed(loaded.summaries);
       let sessions = sessionResult.sessions;
@@ -1365,7 +1409,7 @@ export class StateManager {
         autoLimits: this.autoLimits,
         codexAccount,
         initialRefreshComplete: true,
-        historyWarmupPending: startupPartial,
+        historyWarmupPending: partialHistoryScan,
         historyWarmupStartsAt,
         lastUpdated: Date.now(),
         apiConnected: this.apiConnected,
@@ -1382,14 +1426,16 @@ export class StateManager {
       if (!initialRefreshDone && !force) {
         this.scheduleGitWarmup();
         checkAlerts(derived.limits, settings.alertThresholds, settings.enableAlerts, settings.provider, {
-          deferCodexLocalLog: startupPartial,
+          deferCodexLocalLog: partialHistoryScan,
         });
         await this.logMemorySnapshot('heavyRefresh:end', loaded.scannedFiles);
         if (!this.uiVisible) this.startWatcher('heavyRefresh:startupsync');
+        else this.scheduleWideWatcherPromotion();
         this.logPerfTrace('heavyRefresh', totalPerf, {
           force,
           scannedFiles: loaded.scannedFiles,
           partial: loaded.partial,
+          scanBudgetMs: effectiveScanBudgetMs,
           ...(apiPerf ? this.perfFields('api', apiPerf) : {}),
           ...(loadPerf ? this.perfFields('load', loadPerf) : {}),
           ...(sessionPerf ? this.perfFields('sessions', sessionPerf) : {}),
@@ -1413,7 +1459,7 @@ export class StateManager {
         autoLimits: this.autoLimits,
         codexAccount,
         initialRefreshComplete: true,
-        historyWarmupPending: startupPartial,
+        historyWarmupPending: partialHistoryScan,
         historyWarmupStartsAt,
         lastUpdated: Date.now(),
         apiConnected: this.apiConnected,
@@ -1429,7 +1475,7 @@ export class StateManager {
       this.onUpdate(this.state);
 
       checkAlerts(derived.limits, settings.alertThresholds, settings.enableAlerts, settings.provider, {
-        deferCodexLocalLog: startupPartial,
+        deferCodexLocalLog: partialHistoryScan,
       });
       await this.logMemorySnapshot('heavyRefresh:end', loaded.scannedFiles);
       if (!this.uiVisible) this.startWatcher('heavyRefresh:hidden');
@@ -1437,6 +1483,7 @@ export class StateManager {
         force,
         scannedFiles: loaded.scannedFiles,
         partial: loaded.partial,
+        scanBudgetMs: effectiveScanBudgetMs,
         ...(apiPerf ? this.perfFields('api', apiPerf) : {}),
         ...(loadPerf ? this.perfFields('load', loadPerf) : {}),
         ...(sessionPerf ? this.perfFields('sessions', sessionPerf) : {}),

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -335,6 +335,7 @@ export class StateManager {
   private static readonly STARTUP_SCAN_BUDGET_MS = 2_500;
   private static readonly FOREGROUND_REFRESH_DELAY_MS = 750;
   private static readonly FOREGROUND_SCAN_BUDGET_MS = 2_500;
+  private static readonly FOREGROUND_WARMUP_DELAY_MS = 3_000;
   private static readonly WIDE_WATCHER_PROMOTION_DELAY_MS = 5_000;
   private static readonly STARTUP_WARMUP_DELAY_MS = 30_000;
   private static readonly STARTUP_GIT_DELAY_MS = 60_000;
@@ -1392,7 +1393,7 @@ export class StateManager {
       const partialHistoryScan = effectiveScanBudgetMs !== null && loaded.partial;
       const showHistoryWarmupBanner = allowStartupBudget && !initialRefreshDone && loaded.partial;
       const historyWarmupStartsAt = partialHistoryScan
-        ? this.scheduleHistoryWarmup()
+        ? this.scheduleHistoryWarmup(showHistoryWarmupBanner ? StateManager.STARTUP_WARMUP_DELAY_MS : StateManager.FOREGROUND_WARMUP_DELAY_MS)
         : null;
       if (!partialHistoryScan) this.clearHistoryWarmup();
       const sessionBuildSample = this.beginPerfSample();

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -594,6 +594,7 @@ export class StateManager {
       this.wideWatcherPromotionTimer = null;
       if (!this.uiVisible) return;
       this.startWatcher('popup:show:wide', 'wide');
+      this.scheduleForegroundRefresh();
     }, StateManager.WIDE_WATCHER_PROMOTION_DELAY_MS);
   }
 
@@ -901,12 +902,12 @@ export class StateManager {
     });
   }
 
-  private scheduleHistoryWarmup(delayMs = StateManager.STARTUP_WARMUP_DELAY_MS): number {
+  private scheduleHistoryWarmup(delayMs = StateManager.STARTUP_WARMUP_DELAY_MS, allowHiddenFullScan = false): number {
     if (this.historyWarmupTimer) clearTimeout(this.historyWarmupTimer);
     const startsAt = Date.now() + delayMs;
     this.historyWarmupTimer = setTimeout(() => {
       this.historyWarmupTimer = null;
-      void this.heavyRefresh();
+      void this.heavyRefresh(false, false, null, allowHiddenFullScan);
     }, delayMs);
     return startsAt;
   }
@@ -1312,7 +1313,12 @@ export class StateManager {
     this.onUpdate(this.state);
   }
 
-  private async heavyRefresh(force = false, allowStartupBudget = false, scanBudgetMs: number | null = null) {
+  private async heavyRefresh(
+    force = false,
+    allowStartupBudget = false,
+    scanBudgetMs: number | null = null,
+    allowHiddenFullScan = false,
+  ) {
     const totalPerf = this.beginPerfSample();
     let apiPerf: PerfMetrics | null = null;
     let loadPerf: PerfMetrics | null = null;
@@ -1340,7 +1346,7 @@ export class StateManager {
       apiPerf = this.finishPerfSample(apiSample);
       const initialRefreshDone = this.state.initialRefreshComplete;
       const effectiveScanBudgetMs = scanBudgetMs ?? (allowStartupBudget && !initialRefreshDone ? StateManager.STARTUP_SCAN_BUDGET_MS : null);
-      if (!force && initialRefreshDone && !this.uiVisible) {
+      if (!force && !allowHiddenFullScan && initialRefreshDone && !this.uiVisible) {
         const sessionSample = this.beginPerfSample();
         const settings = this.getSettings();
         const derived = this.computeDerivedUsage(settings);
@@ -1384,22 +1390,29 @@ export class StateManager {
       const loaded = await this.loadProviderSummaries(force, effectiveScanBudgetMs);
       loadPerf = this.finishPerfSample(loadSample);
       this.jsonlCache.flushPersisted();
-      this.summaries = loaded.summaries;
-      this.codexRateLimits = loaded.codexRateLimits;
+      const partialHistoryScan = effectiveScanBudgetMs !== null && loaded.partial;
+      const nextSummaries = partialHistoryScan && initialRefreshDone
+        ? new Map([...this.summaries, ...loaded.summaries])
+        : loaded.summaries;
+      const nextCodexRateLimits = partialHistoryScan && initialRefreshDone
+        ? this.mergeCodexRateLimits(this.codexRateLimits, loaded.codexRateLimits ?? undefined)
+        : loaded.codexRateLimits;
+      this.summaries = nextSummaries;
+      this.codexRateLimits = nextCodexRateLimits;
 
       const settings = this.getSettings();
       const derived = this.computeDerivedUsage(settings);
       const codexAccount = readCodexAccountState();
-      const partialHistoryScan = effectiveScanBudgetMs !== null && loaded.partial;
       const showHistoryWarmupBanner = allowStartupBudget && !initialRefreshDone && loaded.partial;
       const historyWarmupStartsAt = partialHistoryScan
-        ? this.scheduleHistoryWarmup(showHistoryWarmupBanner ? StateManager.STARTUP_WARMUP_DELAY_MS : StateManager.FOREGROUND_WARMUP_DELAY_MS)
+        ? this.scheduleHistoryWarmup(
+            showHistoryWarmupBanner ? StateManager.STARTUP_WARMUP_DELAY_MS : StateManager.FOREGROUND_WARMUP_DELAY_MS,
+            true,
+          )
         : null;
       if (!partialHistoryScan) this.clearHistoryWarmup();
       const sessionBuildSample = this.beginPerfSample();
-      sessionResult = partialHistoryScan
-        ? this.buildScopedSessionInfosDetailed(loaded.summaries)
-        : this.buildScopedSessionInfosDetailed(loaded.summaries);
+      sessionResult = this.buildScopedSessionInfosDetailed(nextSummaries);
       let sessions = sessionResult.sessions;
       sessionPerf = this.finishPerfSample(sessionBuildSample);
       const partialCodeOutputStats = this.buildCodeOutputStats(sessions, this.state.repoGitStats);

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -1390,6 +1390,7 @@ export class StateManager {
       const derived = this.computeDerivedUsage(settings);
       const codexAccount = readCodexAccountState();
       const partialHistoryScan = effectiveScanBudgetMs !== null && loaded.partial;
+      const showHistoryWarmupBanner = allowStartupBudget && !initialRefreshDone && loaded.partial;
       const historyWarmupStartsAt = partialHistoryScan
         ? this.scheduleHistoryWarmup()
         : null;
@@ -1409,8 +1410,8 @@ export class StateManager {
         autoLimits: this.autoLimits,
         codexAccount,
         initialRefreshComplete: true,
-        historyWarmupPending: partialHistoryScan,
-        historyWarmupStartsAt,
+        historyWarmupPending: showHistoryWarmupBanner,
+        historyWarmupStartsAt: showHistoryWarmupBanner ? historyWarmupStartsAt : null,
         lastUpdated: Date.now(),
         apiConnected: this.apiConnected,
         apiStatusLabel: this.apiStatusLabel || undefined,
@@ -1459,8 +1460,8 @@ export class StateManager {
         autoLimits: this.autoLimits,
         codexAccount,
         initialRefreshComplete: true,
-        historyWarmupPending: partialHistoryScan,
-        historyWarmupStartsAt,
+        historyWarmupPending: showHistoryWarmupBanner,
+        historyWarmupStartsAt: showHistoryWarmupBanner ? historyWarmupStartsAt : null,
         lastUpdated: Date.now(),
         apiConnected: this.apiConnected,
         apiStatusLabel: this.apiStatusLabel || undefined,


### PR DESCRIPTION
## Summary

This pr is to fix the issue of main window not response when popup by hotkey.

- Show the popup from cached state instead of coupling the hotkey path to refresh work.
- Defer foreground refresh after the first visible moment and apply a bounded scan budget.
- Start with a recent-session watcher on popup show, then promote to the wide watcher after a delay.
- Add regression guards for cached-state popup display, delayed refresh scheduling, watcher promotion, and full manual refresh behavior.

## Root Cause

Showing the popup could synchronously trigger heavyweight local Claude/Codex history scanning and immediately widen file watchers across JSONL trees. On systems with large local histories, that made the global hotkey feel like the app was frozen before the dashboard became usable.

## Validation

- node --test scripts/state-readiness.test.mjs scripts/stability-regressions.test.mjs passes externally: 51/51.
- npm.cmd test passes externally: 122/122.
- npm.cmd run build passes.

Note: the first targeted test attempt inside the Codex sandbox hit an AppData electron-store EPERM; the same command passed in the normal local environment.