### PR TITLE
Fix compact widget taskbar guard

### DIFF
--- a/scripts/state-readiness.test.mjs
+++ b/scripts/state-readiness.test.mjs
@@ -137,6 +137,10 @@ test('settings and widget integration guard malformed persisted values', () => {
   assert.match(mainSource, /const widgetVisible = .*widgetWindow.*isVisible\(\)/);
   assert.match(mainSource, /const foregroundVisible = popupVisible \|\| widgetVisible/);
   assert.match(mainSource, /stateManager\?\.setUiVisible\(foregroundVisible\)/);
+  assert.match(mainSource, /function keepWindowOutOfTaskbar\(win: BrowserWindow\)/);
+  assert.match(mainSource, /win\.setSkipTaskbar\(true\)/);
+  assert.match(mainSource, /keepWindowOutOfTaskbar\(popupWindow\)/);
+  assert.match(mainSource, /keepWindowOutOfTaskbar\(win\)/);
   assert.match(mainSource, /readyWidgetWindows/);
   assert.doesNotMatch(mainSource, /did-finish-load[^;]+revealCompactWidget/);
   assert.match(mainSource, /schedulePersistWidgetPosition/);

--- a/scripts/state-readiness.test.mjs
+++ b/scripts/state-readiness.test.mjs
@@ -141,6 +141,11 @@ test('settings and widget integration guard malformed persisted values', () => {
   assert.match(mainSource, /win\.setSkipTaskbar\(true\)/);
   assert.match(mainSource, /keepWindowOutOfTaskbar\(popupWindow\)/);
   assert.match(mainSource, /keepWindowOutOfTaskbar\(win\)/);
+  const widgetDragStart = mainSource.indexOf("ipcMain.handle('window:set-compact-widget-position'");
+  const widgetDragEnd = mainSource.indexOf("ipcMain.handle('theme:resolved'", widgetDragStart);
+  const widgetDragBody = mainSource.slice(widgetDragStart, widgetDragEnd);
+  assert.match(widgetDragBody, /widgetWindow\.setBounds/);
+  assert.match(widgetDragBody, /keepWindowOutOfTaskbar\(widgetWindow\)/);
   assert.match(mainSource, /readyWidgetWindows/);
   assert.doesNotMatch(mainSource, /did-finish-load[^;]+revealCompactWidget/);
   assert.match(mainSource, /schedulePersistWidgetPosition/);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -124,6 +124,13 @@ function createTray(): Tray {
   return t;
 }
 
+function keepWindowOutOfTaskbar(win: BrowserWindow) {
+  if (win.isDestroyed()) return;
+  try {
+    win.setSkipTaskbar(true);
+  } catch { /* ignore transient window teardown races */ }
+}
+
 function createPopupWindow(): BrowserWindow {
   const settings = getSettings();
   const win = new BrowserWindow({
@@ -142,11 +149,15 @@ function createPopupWindow(): BrowserWindow {
     },
   });
 
+  keepWindowOutOfTaskbar(win);
   installNavigationGuards(win);
   const rendererPath = path.join(app.getAppPath(), 'dist', 'renderer', 'index.html');
   win.loadFile(rendererPath);
   win.on('move', markPopupMoving);
-  win.on('show', syncUiVisibility);
+  win.on('show', () => {
+    keepWindowOutOfTaskbar(win);
+    syncUiVisibility();
+  });
   win.on('hide', syncUiVisibility);
   win.webContents.on('context-menu', openDashboardContextMenu);
   registerDebugTargets();
@@ -233,6 +244,7 @@ function applyCompactWidgetBounds(settings = getSettings()) {
   const [x, y] = widgetWindow.getPosition();
   const position = constrainWidgetPosition({ x, y }, size);
   widgetWindow.setBounds({ ...position, ...size }, false);
+  keepWindowOutOfTaskbar(widgetWindow);
   if (position.x !== x || position.y !== y) schedulePersistWidgetPosition(widgetWindow);
 }
 
@@ -241,7 +253,9 @@ function revealCompactWidget(win = widgetWindow, settings = getSettings()) {
   if (!win.isVisible() && !readyWidgetWindows.has(win)) return;
   applyCompactWidgetBounds(settings);
   win.setAlwaysOnTop(true);
+  keepWindowOutOfTaskbar(win);
   if (!win.isVisible()) win.showInactive();
+  keepWindowOutOfTaskbar(win);
   syncUiVisibility();
   const currentState = stateManager?.getState();
   if (currentState) win.webContents.send('state:updated', currentState);
@@ -297,11 +311,15 @@ function createWidgetWindow(): BrowserWindow {
     },
   });
 
+  keepWindowOutOfTaskbar(win);
   installNavigationGuards(win);
   const rendererPath = path.join(app.getAppPath(), 'dist', 'renderer', 'index.html');
   win.loadFile(rendererPath, { query: { view: 'widget' } });
   win.on('move', () => schedulePersistWidgetPosition(win));
-  win.on('show', syncWidgetVisibility);
+  win.on('show', () => {
+    keepWindowOutOfTaskbar(win);
+    syncWidgetVisibility();
+  });
   win.on('hide', syncWidgetVisibility);
   win.once('ready-to-show', () => {
     readyWidgetWindows.add(win);
@@ -379,6 +397,7 @@ function showPopup(view: AppView = 'main') {
   popupWindow.setBounds(resolvePopupBounds(tray.getBounds()));
   popupWindow.show();
   popupWindow.focus();
+  keepWindowOutOfTaskbar(popupWindow);
   sendPopupNavigation(view);
   const currentState = stateManager?.getState();
   if (currentState) {
@@ -397,6 +416,7 @@ function sendWidgetStateUpdate(state: AppState) {
   }
   if (!widgetWindow.isVisible()) return;
   applyCompactWidgetBounds(state.settings);
+  keepWindowOutOfTaskbar(widgetWindow);
   widgetWindow.webContents.send('state:updated', state);
 }
 
@@ -442,9 +462,11 @@ function applyWindowSettings() {
   const settings = getSettings();
   if (popupWindow && !popupWindow.isDestroyed()) {
     popupWindow.setAlwaysOnTop(settings.alwaysOnTop);
+    keepWindowOutOfTaskbar(popupWindow);
   }
   if (widgetWindow && !widgetWindow.isDestroyed()) {
     widgetWindow.setAlwaysOnTop(true);
+    keepWindowOutOfTaskbar(widgetWindow);
   }
 }
 
@@ -557,6 +579,7 @@ function updateTray(state: AppState) {
 
 function queueRendererStateUpdate(state: AppState) {
   if (!popupWindow || popupWindow.isDestroyed() || !popupWindow.isVisible()) return;
+  keepWindowOutOfTaskbar(popupWindow);
   pendingStateUpdate = state;
   if (stateUpdateTimer) clearTimeout(stateUpdateTimer);
   stateUpdateTimer = setTimeout(flushRendererStateUpdate, popupMoving ? 250 : 150);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -128,7 +128,7 @@ function keepWindowOutOfTaskbar(win: BrowserWindow) {
   if (win.isDestroyed()) return;
   try {
     win.setSkipTaskbar(true);
-  } catch { /* ignore transient window teardown races */ }
+  } catch { /* 창 종료 타이밍과 겹치는 일시적 오류는 무시한다. */ }
 }
 
 function createPopupWindow(): BrowserWindow {
@@ -688,6 +688,7 @@ app.whenReady().then(() => {
     const size = compactWidgetSize(getSettings());
     const next = constrainWidgetPosition({ x: position.x, y: position.y }, size);
     widgetWindow.setBounds({ ...next, width: size.width, height: size.height });
+    keepWindowOutOfTaskbar(widgetWindow);
     schedulePersistWidgetPosition(widgetWindow);
   });
 


### PR DESCRIPTION
## Summary
- Builds on #14 by reapplying `setSkipTaskbar(true)` after the compact widget drag IPC updates window bounds.
- Adds a regression guard so the `window:set-compact-widget-position` path keeps the widget out of the taskbar.
- Converts the new teardown-race comment to Korean to match the repo rule.

## Review context
A delegated review of #14 found one remaining bounds-change path: dragging the compact widget calls `widgetWindow.setBounds(...)` directly, bypassing the new taskbar guard added to the other show/update paths.

## Validation
- `node --test scripts/state-readiness.test.mjs`
- `npm run build`
- `npm test` (118/118)
- `scripts/review-privacy.ps1` (Gitleaks git/dir: no leaks detected)