### PR TITLE
feat. Route refresh work through a scheduler to prevent UI freezes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:main": "tsc",
     "build:renderer": "node scripts/build-renderer.mjs",
     "build": "node scripts/make-icons.mjs && npm run build:main && npm run build:renderer",
-    "test": "npm run build:main && node --test scripts/session-metadata.test.mjs scripts/git-stats-keys.test.mjs scripts/git-stats-daily.test.mjs scripts/state-readiness.test.mjs scripts/integration.test.mjs scripts/jsonl-summary.test.mjs scripts/rate-limit-fetcher.test.mjs scripts/oauth-refresh.test.mjs scripts/codex-usage-fetcher.test.mjs scripts/stability-regressions.test.mjs",
+    "test": "npm run build:main && node --test scripts/session-metadata.test.mjs scripts/git-stats-keys.test.mjs scripts/git-stats-daily.test.mjs scripts/refresh-scheduler.test.mjs scripts/state-readiness.test.mjs scripts/integration.test.mjs scripts/jsonl-summary.test.mjs scripts/rate-limit-fetcher.test.mjs scripts/oauth-refresh.test.mjs scripts/codex-usage-fetcher.test.mjs scripts/stability-regressions.test.mjs",
     "start": "npm run build && electron .",
     "dev": "concurrently \"tsc -w\" \"wait-on dist/main/index.js && npm run build:renderer && electron .\"",
     "pack": "npm run build && electron-builder --dir",

--- a/scripts/refresh-scheduler.test.mjs
+++ b/scripts/refresh-scheduler.test.mjs
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import refreshSchedulerModule from '../dist/main/refreshScheduler.js';
+
+const { RefreshScheduler } = refreshSchedulerModule;
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function tick() {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+test('refresh scheduler runs one task at a time and merges overlapping file changes', async () => {
+  const gate = deferred();
+  const works = [];
+  let active = 0;
+  let maxActive = 0;
+  const scheduler = new RefreshScheduler({
+    foregroundScanBudgetMs: 2500,
+    getState: () => ({ uiVisible: true, uiBusy: false }),
+    execute: async (work) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      works.push(work);
+      if (works.length === 1) await gate.promise;
+      active -= 1;
+    },
+  });
+
+  const first = scheduler.request({ mode: 'fast', reason: 'watcher', changedFiles: ['a.jsonl'] });
+  await tick();
+  const second = scheduler.request({ mode: 'fast', reason: 'watcher', changedFiles: ['b.jsonl', 'a.jsonl'] });
+  await tick();
+
+  assert.equal(works.length, 1);
+  assert.equal(maxActive, 1);
+
+  gate.resolve();
+  await Promise.all([first, second]);
+
+  assert.equal(works.length, 2);
+  assert.deepEqual([...works[1].changedFiles].sort(), ['a.jsonl', 'b.jsonl']);
+  assert.equal(maxActive, 1);
+});
+
+test('heavy refresh supersedes pending fast refresh and keeps foreground scan budget', async () => {
+  const gate = deferred();
+  const works = [];
+  const scheduler = new RefreshScheduler({
+    foregroundScanBudgetMs: 2500,
+    getState: () => ({ uiVisible: true, uiBusy: false }),
+    execute: async (work) => {
+      works.push(work);
+      if (works.length === 1) await gate.promise;
+    },
+  });
+
+  const first = scheduler.request({ mode: 'fast', reason: 'watcher', changedFiles: ['a.jsonl'] });
+  await tick();
+  const pendingFast = scheduler.request({ mode: 'fast', reason: 'watcher', changedFiles: ['b.jsonl'] });
+  const pendingHeavy = scheduler.request({ mode: 'heavy', reason: 'foreground' });
+  await tick();
+
+  gate.resolve();
+  await Promise.all([first, pendingFast, pendingHeavy]);
+
+  assert.equal(works.length, 2);
+  assert.equal(works[1].mode, 'heavy');
+  assert.equal(works[1].scanBudgetMs, 2500);
+  assert.deepEqual([...works[1].changedFiles], ['b.jsonl']);
+  assert.deepEqual(works[1].reasons.sort(), ['foreground', 'watcher']);
+});
+
+test('hidden heavy refresh can run without a foreground budget', async () => {
+  const works = [];
+  const scheduler = new RefreshScheduler({
+    foregroundScanBudgetMs: 2500,
+    getState: () => ({ uiVisible: false, uiBusy: false }),
+    execute: async (work) => {
+      works.push(work);
+    },
+  });
+
+  await scheduler.request({ mode: 'heavy', reason: 'timer', allowHiddenFullScan: true });
+
+  assert.equal(works.length, 1);
+  assert.equal(works[0].scanBudgetMs, null);
+  assert.equal(works[0].allowHiddenFullScan, true);
+});
+
+test('non-forced refresh waits while UI is busy', async () => {
+  const works = [];
+  let uiBusy = true;
+  const scheduler = new RefreshScheduler({
+    foregroundScanBudgetMs: 2500,
+    getState: () => ({ uiVisible: true, uiBusy }),
+    execute: async (work) => {
+      works.push(work);
+    },
+  });
+
+  const request = scheduler.request({ mode: 'heavy', reason: 'foreground' });
+  await tick();
+  assert.equal(works.length, 0);
+
+  uiBusy = false;
+  scheduler.notifyStateChanged();
+  await request;
+
+  assert.equal(works.length, 1);
+  assert.equal(works[0].scanBudgetMs, 2500);
+});

--- a/scripts/refresh-scheduler.test.mjs
+++ b/scripts/refresh-scheduler.test.mjs
@@ -80,7 +80,7 @@ test('heavy refresh supersedes pending fast refresh and keeps foreground scan bu
   assert.deepEqual(works[1].reasons.sort(), ['foreground', 'watcher']);
 });
 
-test('hidden heavy refresh can run without a foreground budget', async () => {
+test('hidden automatic heavy refresh still keeps a scan budget so hotkeys stay responsive', async () => {
   const works = [];
   const scheduler = new RefreshScheduler({
     foregroundScanBudgetMs: 2500,
@@ -93,8 +93,24 @@ test('hidden heavy refresh can run without a foreground budget', async () => {
   await scheduler.request({ mode: 'heavy', reason: 'timer', allowHiddenFullScan: true });
 
   assert.equal(works.length, 1);
-  assert.equal(works[0].scanBudgetMs, null);
+  assert.equal(works[0].scanBudgetMs, 2500);
   assert.equal(works[0].allowHiddenFullScan, true);
+});
+
+test('manual force refresh can still request an unbudgeted scan', async () => {
+  const works = [];
+  const scheduler = new RefreshScheduler({
+    foregroundScanBudgetMs: 2500,
+    getState: () => ({ uiVisible: false, uiBusy: false }),
+    execute: async (work) => {
+      works.push(work);
+    },
+  });
+
+  await scheduler.request({ mode: 'heavy', reason: 'manual', force: true });
+
+  assert.equal(works.length, 1);
+  assert.equal(works[0].scanBudgetMs, null);
 });
 
 test('non-forced refresh waits while UI is busy', async () => {

--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -1106,7 +1106,12 @@ test('foreground refresh uses a scan budget while force refresh remains full', (
   const heavyEnd = source.indexOf('  private buildStartupPriorityFiles', heavyStart);
   const heavyBody = source.slice(heavyStart, heavyEnd);
 
-  assert.match(scheduleBody, /this\.heavyRefresh\(false, false, StateManager\.FOREGROUND_SCAN_BUDGET_MS\)/);
+  assert.match(source, /new RefreshScheduler\(\{/);
+  assert.match(source, /execute: \(work\) => this\.executeRefresh\(work\)/);
+  assert.match(scheduleBody, /this\.requestRefresh\(\{/);
+  assert.match(scheduleBody, /mode: 'heavy'/);
+  assert.match(scheduleBody, /reason: 'foreground'/);
+  assert.match(scheduleBody, /scanBudgetMs: StateManager\.FOREGROUND_SCAN_BUDGET_MS/);
   assert.match(source, /FOREGROUND_WARMUP_DELAY_MS = 3_000/);
   assert.match(heavyBody, /scanBudgetMs: number \| null = null/);
   assert.match(heavyBody, /allowHiddenFullScan = false/);
@@ -1123,6 +1128,6 @@ test('foreground refresh uses a scan budget while force refresh remains full', (
   assert.match(heavyBody, /historyWarmupPending: showHistoryWarmupBanner/);
   assert.match(heavyBody, /historyWarmupStartsAt: showHistoryWarmupBanner \? historyWarmupStartsAt : null/);
   assert.doesNotMatch(heavyBody, /historyWarmupPending: partialHistoryScan/);
-  assert.match(forceBody, /await this\.heavyRefresh\(true\)/);
+  assert.match(forceBody, /await this\.requestRefresh\(\{ mode: 'heavy', reason: 'manual', force: true \}\)/);
   assert.doesNotMatch(forceBody, /FOREGROUND_SCAN_BUDGET_MS/);
 });

--- a/src/main/refreshScheduler.ts
+++ b/src/main/refreshScheduler.ts
@@ -1,0 +1,168 @@
+export type RefreshMode = 'fast' | 'heavy';
+
+export type RefreshReason =
+  | 'startup'
+  | 'foreground'
+  | 'history-warmup'
+  | 'timer'
+  | 'watcher'
+  | 'ui-idle'
+  | 'manual'
+  | 'settings';
+
+export interface RefreshRequest {
+  mode: RefreshMode;
+  reason: RefreshReason;
+  changedFiles?: Iterable<string>;
+  force?: boolean;
+  allowStartupBudget?: boolean;
+  allowHiddenFullScan?: boolean;
+  scanBudgetMs?: number | null;
+}
+
+export interface RefreshWork {
+  mode: RefreshMode;
+  reasons: RefreshReason[];
+  changedFiles?: Set<string>;
+  force: boolean;
+  allowStartupBudget: boolean;
+  allowHiddenFullScan: boolean;
+  scanBudgetMs: number | null;
+}
+
+export interface RefreshSchedulerState {
+  uiVisible: boolean;
+  uiBusy: boolean;
+}
+
+interface PendingRefresh {
+  mode: RefreshMode;
+  reasons: Set<RefreshReason>;
+  changedFiles: Set<string>;
+  force: boolean;
+  allowStartupBudget: boolean;
+  allowHiddenFullScan: boolean;
+  scanBudgetMs: number | null | undefined;
+  waiters: Array<{ resolve: () => void; reject: (error: unknown) => void }>;
+}
+
+export interface RefreshSchedulerOptions {
+  foregroundScanBudgetMs: number;
+  getState: () => RefreshSchedulerState;
+  execute: (work: RefreshWork) => Promise<void>;
+}
+
+export class RefreshScheduler {
+  private pending: PendingRefresh | null = null;
+  private running = false;
+  private drainScheduled = false;
+
+  constructor(private readonly options: RefreshSchedulerOptions) {}
+
+  request(request: RefreshRequest): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.pending = this.mergePending(this.pending, request, { resolve, reject });
+      this.scheduleDrain();
+    });
+  }
+
+  notifyStateChanged(): void {
+    this.scheduleDrain();
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  getPendingChangedFileCount(): number {
+    return this.pending?.changedFiles.size ?? 0;
+  }
+
+  private mergePending(
+    current: PendingRefresh | null,
+    request: RefreshRequest,
+    waiter: { resolve: () => void; reject: (error: unknown) => void },
+  ): PendingRefresh {
+    const changedFiles = current?.changedFiles ?? new Set<string>();
+    for (const file of request.changedFiles ?? []) changedFiles.add(file);
+
+    const reasons = current?.reasons ?? new Set<RefreshReason>();
+    reasons.add(request.reason);
+
+    return {
+      mode: current?.mode === 'heavy' || request.mode === 'heavy' ? 'heavy' : 'fast',
+      reasons,
+      changedFiles,
+      force: (current?.force ?? false) || request.force === true,
+      allowStartupBudget: (current?.allowStartupBudget ?? false) || request.allowStartupBudget === true,
+      allowHiddenFullScan: (current?.allowHiddenFullScan ?? false) || request.allowHiddenFullScan === true,
+      scanBudgetMs: this.mergeScanBudget(current?.scanBudgetMs, request.scanBudgetMs),
+      waiters: [...(current?.waiters ?? []), waiter],
+    };
+  }
+
+  private mergeScanBudget(current: number | null | undefined, next: number | null | undefined): number | null | undefined {
+    if (next === undefined) return current;
+    if (current === undefined) return next;
+    if (current === null || next === null) return null;
+    return Math.min(current, next);
+  }
+
+  private scheduleDrain(): void {
+    if (this.drainScheduled) return;
+    this.drainScheduled = true;
+    queueMicrotask(() => {
+      this.drainScheduled = false;
+      void this.drain();
+    });
+  }
+
+  private async drain(): Promise<void> {
+    if (this.running) return;
+
+    while (this.pending) {
+      const work = this.takeRunnableWork();
+      if (!work) return;
+
+      this.running = true;
+      try {
+        await this.options.execute(work.work);
+        for (const waiter of work.waiters) waiter.resolve();
+      } catch (error) {
+        for (const waiter of work.waiters) waiter.reject(error);
+      } finally {
+        this.running = false;
+      }
+    }
+  }
+
+  private takeRunnableWork(): { work: RefreshWork; waiters: PendingRefresh['waiters'] } | null {
+    const pending = this.pending;
+    if (!pending) return null;
+
+    const state = this.options.getState();
+    if (state.uiBusy && !pending.force) return null;
+
+    this.pending = null;
+    const scanBudgetMs = this.resolveScanBudget(pending, state);
+    return {
+      work: {
+        mode: pending.mode,
+        reasons: [...pending.reasons],
+        changedFiles: pending.changedFiles.size > 0 ? new Set(pending.changedFiles) : undefined,
+        force: pending.force,
+        allowStartupBudget: pending.allowStartupBudget,
+        allowHiddenFullScan: !state.uiVisible && pending.allowHiddenFullScan,
+        scanBudgetMs,
+      },
+      waiters: pending.waiters,
+    };
+  }
+
+  private resolveScanBudget(pending: PendingRefresh, state: RefreshSchedulerState): number | null {
+    if (pending.mode === 'fast') return null;
+    if (pending.scanBudgetMs !== undefined) return pending.scanBudgetMs;
+    if (pending.force) return null;
+    return state.uiVisible ? this.options.foregroundScanBudgetMs : null;
+  }
+}

--- a/src/main/refreshScheduler.ts
+++ b/src/main/refreshScheduler.ts
@@ -163,6 +163,6 @@ export class RefreshScheduler {
     if (pending.mode === 'fast') return null;
     if (pending.scanBudgetMs !== undefined) return pending.scanBudgetMs;
     if (pending.force) return null;
-    return state.uiVisible ? this.options.foregroundScanBudgetMs : null;
+    return this.options.foregroundScanBudgetMs;
   }
 }

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -19,6 +19,7 @@ import { ActivityBreakdown, ActivityBreakdownKind, CodexRateLimitWindow, FileUsa
 import { CodexAccountState, readCodexAccountState } from './codexAccount';
 import { appendDebugMemoryLog, collectRuntimeMemorySnapshot, isDebugInstrumentationEnabled } from './debugInstrumentation';
 import { getOAuthCredentialMarker } from './oauthRefresh';
+import { RefreshRequest, RefreshScheduler, RefreshWork } from './refreshScheduler';
 
 export interface SessionInfo extends DiscoveredSession {
   modelName: string;
@@ -307,14 +308,12 @@ export class StateManager {
   private codexUsageBackoffMs = 0;
   private codexUsageRequestSeq = 0;
   private bridgeWatcher: BridgeWatcher;
+  private refreshScheduler: RefreshScheduler;
   private liveSession: LiveSessionData | null = null;
   private jsonlCache = new JsonlCache();
   private codexRateLimits: SessionSnapshot['codexRateLimits'] | null = null;
   private gitStatsCache = new Map<string, { stats: GitStats | null; ts: number }>();
   private dirtySessionFiles = new Set<string>();
-  private deferredFastFiles = new Set<string>();
-  private heavyInFlight = false;
-  private heavyPending = false;
   private historyWarmupTimer: NodeJS.Timeout | null = null;
   private gitWarmupTimer: NodeJS.Timeout | null = null;
   private foregroundRefreshTimer: NodeJS.Timeout | null = null;
@@ -353,6 +352,11 @@ export class StateManager {
     this.state = this.emptyState();
     const oauthCredentialMarker = getOAuthCredentialMarker();
     this.lastOAuthCredentialMarker = oauthCredentialMarker;
+    this.refreshScheduler = new RefreshScheduler({
+      foregroundScanBudgetMs: StateManager.FOREGROUND_SCAN_BUDGET_MS,
+      getState: () => ({ uiVisible: this.uiVisible, uiBusy: this.uiBusy }),
+      execute: (work) => this.executeRefresh(work),
+    });
     const cachedRaw = this.getPersistedValue('_cachedApiPct', null);
     const cached = normalizeStoredApiUsagePct(cachedRaw, oauthCredentialMarker);
     if (cachedRaw && !cached) {
@@ -511,7 +515,7 @@ export class StateManager {
 
   start() {
     this.bridgeWatcher.start();
-    void this.heavyRefresh(false, true);
+    void this.requestRefresh({ mode: 'heavy', reason: 'startup', allowStartupBudget: true });
     this.startTimers();
     this.startWatcher();
     this.startDebugMemTimer();
@@ -538,18 +542,31 @@ export class StateManager {
     this.jsonlCache.flushPersisted();
   }
 
+  private requestRefresh(request: RefreshRequest): Promise<void> {
+    const changedFiles = request.changedFiles
+      ? [...request.changedFiles].map(file => normalizeFileKey(file))
+      : undefined;
+    return this.refreshScheduler.request({ ...request, changedFiles });
+  }
+
+  private async executeRefresh(work: RefreshWork): Promise<void> {
+    if (work.mode === 'fast') {
+      await this.fastRefresh(work.changedFiles);
+      return;
+    }
+
+    await this.heavyRefresh(
+      work.force,
+      work.allowStartupBudget,
+      work.scanBudgetMs,
+      work.allowHiddenFullScan,
+      work.changedFiles,
+    );
+  }
+
   setUiBusy(busy: boolean): void {
     this.uiBusy = busy;
-    if (busy) return;
-    if (this.deferredFastFiles.size > 0) {
-      const files = new Set(this.deferredFastFiles);
-      this.deferredFastFiles.clear();
-      void this.fastRefresh(files);
-    }
-    if (this.heavyPending) {
-      this.heavyPending = false;
-      void this.heavyRefresh();
-    }
+    if (!busy) this.refreshScheduler.notifyStateChanged();
   }
 
   setUiVisible(visible: boolean): void {
@@ -562,10 +579,12 @@ export class StateManager {
         this.scheduleForegroundRefresh();
         this.scheduleWideWatcherPromotion();
       }
+      this.refreshScheduler.notifyStateChanged();
       return;
     }
     this.clearForegroundTimers();
     this.startWatcher('popup:hide', 'recent');
+    this.refreshScheduler.notifyStateChanged();
   }
 
   private clearForegroundTimers(): void {
@@ -584,7 +603,11 @@ export class StateManager {
         this.scheduleForegroundRefresh();
         return;
       }
-      void this.heavyRefresh(false, false, StateManager.FOREGROUND_SCAN_BUDGET_MS);
+      void this.requestRefresh({
+        mode: 'heavy',
+        reason: 'foreground',
+        scanBudgetMs: StateManager.FOREGROUND_SCAN_BUDGET_MS,
+      });
     }, StateManager.FOREGROUND_REFRESH_DELAY_MS);
   }
 
@@ -654,7 +677,7 @@ export class StateManager {
       cachePersistedLimit: cacheStats.persistedLimit,
       gitCacheEntries: this.gitStatsCache.size,
       dirtyFiles: this.dirtySessionFiles.size,
-      deferredFastFiles: this.deferredFastFiles.size,
+      deferredFastFiles: this.refreshScheduler.getPendingChangedFileCount(),
     };
   }
 
@@ -713,7 +736,7 @@ export class StateManager {
         repoGitStats: Object.keys(this.state.repoGitStats).length,
         gitStatsCache: this.gitStatsCache.size,
         dirtySessionFiles: this.dirtySessionFiles.size,
-        deferredFastFiles: this.deferredFastFiles.size,
+        deferredFastFiles: this.refreshScheduler.getPendingChangedFileCount(),
       },
       watcher: {
         profile: this.watcherProfile,
@@ -876,7 +899,7 @@ export class StateManager {
   async forceRefresh(): Promise<void> {
     this.clearHistoryWarmup();
     this.clearGitWarmup();
-    await this.heavyRefresh(true);
+    await this.requestRefresh({ mode: 'heavy', reason: 'manual', force: true });
   }
 
   private startTimers() {
@@ -888,9 +911,9 @@ export class StateManager {
     const heavyIntervalMs = this.uiVisible
       ? StateManager.HEAVY_REFRESH_VISIBLE_MS
       : StateManager.HEAVY_REFRESH_HIDDEN_MS;
-    this.fastTimer = setInterval(() => { void this.fastRefresh(); }, fastIntervalMs);
+    this.fastTimer = setInterval(() => { void this.requestRefresh({ mode: 'fast', reason: 'timer' }); }, fastIntervalMs);
     this.heavyTimer = setInterval(() => {
-      void this.heavyRefresh(!this.uiVisible);
+      void this.requestRefresh({ mode: 'heavy', reason: 'timer', allowHiddenFullScan: true });
     }, heavyIntervalMs);
     if (!this.isPerfDebugEnabled()) return;
     console.info('[WhereMyTokens][runtime]', {
@@ -907,7 +930,7 @@ export class StateManager {
     const startsAt = Date.now() + delayMs;
     this.historyWarmupTimer = setTimeout(() => {
       this.historyWarmupTimer = null;
-      void this.heavyRefresh(false, false, null, allowHiddenFullScan);
+      void this.requestRefresh({ mode: 'heavy', reason: 'history-warmup', allowHiddenFullScan });
     }, delayMs);
     return startsAt;
   }
@@ -1122,7 +1145,7 @@ export class StateManager {
       this.fastDebounce = null;
       const files = this.dirtySessionFiles.size > 0 ? new Set(this.dirtySessionFiles) : undefined;
       this.dirtySessionFiles.clear();
-      void this.fastRefresh(files);
+      void this.requestRefresh({ mode: 'fast', reason: 'watcher', changedFiles: files });
     }, 1200);
   }
 
@@ -1222,7 +1245,7 @@ export class StateManager {
       if (filePath.endsWith('.jsonl')) {
         this.debouncedFastRefresh(filePath);
       } else {
-        void this.fastRefresh();
+        void this.requestRefresh({ mode: 'fast', reason: 'watcher' });
       }
     });
     this.watcher.on('unlink', (filePath: string) => {
@@ -1245,10 +1268,6 @@ export class StateManager {
     let changedPerf: PerfMetrics | null = null;
     let sessionPerf: PerfMetrics | null = null;
     let sessionResult: SessionBuildResult | null = null;
-    if (this.uiBusy) {
-      if (changedFiles) for (const file of changedFiles) this.deferredFastFiles.add(normalizeFileKey(file));
-      return;
-    }
 
     if (changedFiles && changedFiles.size > 0) {
       const changedSample = this.beginPerfSample();
@@ -1293,7 +1312,7 @@ export class StateManager {
   }
 
   private async refreshGitStatsAfterStartup(): Promise<void> {
-    if (this.uiBusy || this.heavyInFlight) {
+    if (this.uiBusy || this.refreshScheduler.isRunning()) {
       this.scheduleGitWarmup(5_000);
       return;
     }
@@ -1318,6 +1337,7 @@ export class StateManager {
     allowStartupBudget = false,
     scanBudgetMs: number | null = null,
     allowHiddenFullScan = false,
+    priorityFiles?: Set<string>,
   ) {
     const totalPerf = this.beginPerfSample();
     let apiPerf: PerfMetrics | null = null;
@@ -1325,16 +1345,6 @@ export class StateManager {
     let sessionPerf: PerfMetrics | null = null;
     let gitPerf: PerfMetrics | null = null;
     let sessionResult: SessionBuildResult | null = null;
-    if (this.uiBusy && !force) {
-      this.heavyPending = true;
-      return;
-    }
-    if (this.heavyInFlight) {
-      this.heavyPending = true;
-      return;
-    }
-    this.heavyInFlight = true;
-    try {
       await this.logMemorySnapshot('heavyRefresh:start');
       const apiSample = this.beginPerfSample();
       const settingsForApi = this.getSettings();
@@ -1387,7 +1397,7 @@ export class StateManager {
         return;
       }
       const loadSample = this.beginPerfSample();
-      const loaded = await this.loadProviderSummaries(force, effectiveScanBudgetMs);
+      const loaded = await this.loadProviderSummaries(force, effectiveScanBudgetMs, priorityFiles);
       loadPerf = this.finishPerfSample(loadSample);
       this.jsonlCache.flushPersisted();
       const partialHistoryScan = effectiveScanBudgetMs !== null && loaded.partial;
@@ -1505,13 +1515,6 @@ export class StateManager {
         ...(gitPerf ? this.perfFields('git', gitPerf) : {}),
         ...(sessionResult ? this.sessionDebugExtras(sessions, sessionResult) : {}),
       });
-    } finally {
-      this.heavyInFlight = false;
-      if (this.heavyPending && !this.uiBusy) {
-        this.heavyPending = false;
-        void this.heavyRefresh();
-      }
-    }
   }
 
   private buildStartupPriorityFiles(provider: AppSettings['provider']): Set<string> {
@@ -1774,7 +1777,11 @@ export class StateManager {
     this.codexRateLimits = merged;
   }
 
-  private async loadProviderSummaries(force = false, budgetMs: number | null = null): Promise<{
+  private async loadProviderSummaries(
+    force = false,
+    budgetMs: number | null = null,
+    priorityFiles?: Iterable<string>,
+  ): Promise<{
     summaries: Map<string, FileUsageSummary>;
     sessionCount: number;
     codexRateLimits: SessionSnapshot['codexRateLimits'] | null;
@@ -1790,6 +1797,8 @@ export class StateManager {
     let scannedFiles = 0;
     let partial = false;
     const startedAt = Date.now();
+    const explicitPriority = new Set<string>();
+    for (const filePath of priorityFiles ?? []) explicitPriority.add(normalizeFileKey(filePath));
     const startupPriority = budgetMs !== null
       ? this.buildStartupPriorityFiles(settings.provider)
       : new Set(
@@ -1798,6 +1807,7 @@ export class StateManager {
             .filter((filePath): filePath is string => !!filePath)
             .map(filePath => normalizeFileKey(filePath))
         );
+    for (const filePath of explicitPriority) startupPriority.add(filePath);
 
     const shouldStopForBudget = () => budgetMs !== null && Date.now() - startedAt >= budgetMs;
     const shouldPrioritize = (filePath: string) => startupPriority.has(normalizeFileKey(filePath));
@@ -2393,7 +2403,7 @@ export class StateManager {
       this.startWatcher();
       this.clearHistoryWarmup();
       this.clearGitWarmup();
-      void this.heavyRefresh(true);
+      void this.requestRefresh({ mode: 'heavy', reason: 'settings', force: true });
       return;
     }
 
@@ -2442,7 +2452,7 @@ export class StateManager {
         watcherProfile: this.watcherProfile,
         watcherTargets: this.watcherTargetCount,
         dirtyFiles: this.dirtySessionFiles.size,
-        deferredFastFiles: this.deferredFastFiles.size,
+        deferredFastFiles: this.refreshScheduler.getPendingChangedFileCount(),
         scannedFiles,
       });
       appendDebugMemoryLog('memory-snapshot', {
@@ -2459,7 +2469,7 @@ export class StateManager {
           repoGitStats: Object.keys(this.state.repoGitStats).length,
           gitStatsCache: this.gitStatsCache.size,
           dirtySessionFiles: this.dirtySessionFiles.size,
-          deferredFastFiles: this.deferredFastFiles.size,
+          deferredFastFiles: this.refreshScheduler.getPendingChangedFileCount(),
         },
         watcher: {
           profile: this.watcherProfile,


### PR DESCRIPTION
## Summary

This PR eliminates UI freezes for good.

The fix is to route JSONL/session/usage refresh work through a single refresh scheduler instead of allowing refresh requests to overlap or run inline from multiple entry points.

## Root Cause

Refresh work could be triggered from several places: startup, foreground show, timers, watcher events, history warmup, manual refresh, and settings changes. Some of those paths could overlap, and hidden heavy refreshes could still run an unbudgeted scan.

Because Electron global shortcuts are handled on the main process, an expensive hidden full scan could occupy the same process long enough that the hotkey callback itself was delayed. That made the app look frozen and could prevent the main window from being summoned until the scan completed.

## What Changed

- Added `RefreshScheduler` as the single queue for refresh work.
- Routed startup, foreground, timer, watcher, warmup, manual, and settings-triggered refreshes through the scheduler.
- Coalesced overlapping requests so repeated refresh triggers merge instead of piling up.
- Let heavy refresh supersede pending fast refresh while preserving changed JSONL files as priority inputs.
- Made non-forced refresh wait while the UI is marked busy.
- Kept all non-forced heavy refreshes budgeted, including hidden automatic refreshes, so background scanning cannot monopolize the main process.
- Preserved manual force refresh as the explicit unbudgeted full scan path.

## Impact

This directly addresses the freeze class where the page stops responding or the hotkey cannot bring the window back because refresh work is occupying the main process. Refresh requests are now serialized, deduplicated, and budgeted by default, which makes popup show/hide behavior and normal UI interaction much more predictable.

## Validation

- `node --test scripts/refresh-scheduler.test.mjs`
- `npm.cmd test` on the same patch: 127/127 passing
- `npm.cmd run build`
- `npm.cmd run dist`

Packaged artifacts were regenerated under `release/`, and the latest `release/win-unpacked/WhereMyTokens.exe` was launched for local testing.
