### PR TITLE
Fix budgeted ledger completion marker

### DIFF
--- a/scripts/usage-ledger-state.test.mjs
+++ b/scripts/usage-ledger-state.test.mjs
@@ -195,3 +195,19 @@ test('state manager skips persisted usage ledger writes when sources are unchang
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('budgeted full-history ledger scans do not mark the import complete when truncated', async () => {
+  const usageLedgerStore = new CountingUsageLedgerStore(emptyUsageLedgerSnapshot());
+  const manager = new StateManager(makeStore(), () => {});
+  manager.usageLedgerStore = usageLedgerStore;
+  manager.ledgerSourceFiles = () => ({
+    files: [{ filePath: path.join(os.tmpdir(), 'unreached.jsonl'), provider: 'claude', priority: false }],
+    partial: false,
+  });
+
+  const result = await manager.refreshUsageLedgerFromDiscoveredSources(0, undefined, true);
+
+  assert.equal(result.partial, true);
+  assert.equal(result.scannedFiles, 0);
+  assert.equal(usageLedgerStore.snapshot.lastFullImportAt ?? 0, 0);
+});

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -2104,10 +2104,12 @@ export class StateManager {
     let changed = false;
     let scannedFiles = 0;
     let partial = !includeFullHistory && sourceList.partial && !alreadyCompletedFullImport;
+    let stoppedForBudget = false;
 
     const shouldStopForBudget = () => budgetMs !== null && Date.now() - startedAt >= budgetMs;
     for (const source of sourceList.files) {
       if (!source.priority && shouldStopForBudget()) {
+        stoppedForBudget = true;
         partial = !alreadyCompletedFullImport;
         break;
       }
@@ -2122,11 +2124,12 @@ export class StateManager {
       }
     }
 
+    const completedFullImport = includeFullHistory && !stoppedForBudget;
     if (changed) {
-      if (includeFullHistory) snapshot = { ...snapshot, lastFullImportAt: Date.now() };
+      if (completedFullImport) snapshot = { ...snapshot, lastFullImportAt: Date.now() };
       this.usageLedgerStore.replaceSnapshot(snapshot);
       this.usageLedgerStore.compact();
-    } else if (includeFullHistory) {
+    } else if (completedFullImport) {
       this.usageLedgerStore.replaceSnapshot({ ...snapshot, lastFullImportAt: Date.now() });
     }
 


### PR DESCRIPTION
This PR is to fix the issue of truncated full-history scan, which caused incomplete static.

## Summary

- Keep budgeted full-history ledger scans from marking the import complete when they stop early.
- Add a regression test for truncated full-history ledger scans.

## Root cause

Manual and warmup full-history scans can still run with a foreground scan budget. When that budget was exhausted before all sources were imported, the ledger path could still write `lastFullImportAt`. Later refreshes then treated the full import as complete and stopped scheduling warmup work, so historical totals filled in only after repeated manual refreshes.

## Impact

Historical usage totals should continue background warmup after a truncated full-history scan instead of prematurely freezing at a partial ledger snapshot.

## Validation

- `node --test scripts/usage-ledger-state.test.mjs`
- `node --test scripts/usage-ledger-state.test.mjs scripts/stability-regressions.test.mjs scripts/refresh-scheduler.test.mjs`
- `npm.cmd test` (201/201 pass)
- `npm.cmd run dist`