### PR TITLE
Fix quota stability and startup history syncing

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -238,6 +238,8 @@ WhereMyTokens también puede leer los logs JSONL locales de Codex desde `~/.code
 
 El seguimiento de Antigravity se conecta únicamente al language server del IDE Antigravity en ejecución mediante 127.0.0.1 local RPC. Lee cascades de sesión, quota por modelo y generator metadata para alimentar providerQuotas y el usage ledger; no usa Google OAuth, refresh token, Google cloud usage endpoint ni fallback de base de datos offline.
 
+Las tarjetas de quota por modelo de Antigravity son percent-only por defecto. Activa **Antigravity quota pace** en Settings para estimar el pacing de 5h/semanal desde los reset times.
+
 **Cálculo de caché de prompt:** los logs de Codex reportan `input_tokens` y `cached_input_tokens`. WhereMyTokens guarda el input no cacheado como `input_tokens - cached_input_tokens` y el cached input como cache-read tokens. Codex y Antigravity muestran la eficiencia como cache reads sobre prompt tokens:
 
 ```text

--- a/README.ja.md
+++ b/README.ja.md
@@ -238,6 +238,8 @@ WhereMyTokens は Codex のローカル JSONL ログ（`~/.codex/sessions/**/*.j
 
 Antigravity 追跡は、実行中の Antigravity IDE の language server に 127.0.0.1 local RPC でのみ接続します。セッション cascade、モデル quota、generator metadata を読み取り providerQuotas と usage ledger に反映し、Google OAuth、refresh token、Google cloud usage endpoint、オフライン DB fallback は使いません。
 
+Antigravity のモデル quota カードはデフォルトでは percent-only です。Settings の **Antigravity quota pace** を有効にすると、reset time から 5h/weekly pacing を推定します。
+
 **Prompt キャッシュ計算式：** Codex ログは `input_tokens` と `cached_input_tokens` を提供します。WhereMyTokens は uncached input を `input_tokens - cached_input_tokens`、cached input を cache-read token として保存します。Codex と Antigravity は cache read が prompt token に占める割合をキャッシュ効率として表示します。
 
 ```text

--- a/README.ko.md
+++ b/README.ko.md
@@ -238,6 +238,8 @@ WhereMyTokens는 Codex의 로컬 JSONL 로그(`~/.codex/sessions/**/*.jsonl`, `~
 
 Antigravity 추적은 실행 중인 Antigravity IDE의 language server에 127.0.0.1 local RPC로만 연결합니다. 세션 cascade, 모델 quota, generator metadata를 읽어 providerQuotas와 사용량 ledger에 반영하며, Google OAuth, refresh token, Google cloud usage endpoint, 오프라인 DB fallback은 사용하지 않습니다.
 
+Antigravity 모델 quota 카드는 기본적으로 percent-only로 표시됩니다. Settings의 **Antigravity quota pace**를 켜면 reset time으로 5h/weekly pacing을 추정합니다.
+
 **Prompt 캐시 계산식:** Codex 로그는 `input_tokens`와 `cached_input_tokens`를 제공합니다. WhereMyTokens는 uncached input을 `input_tokens - cached_input_tokens`로, cached input을 cache-read token으로 저장합니다. Codex와 Antigravity는 cache read가 prompt token에서 차지하는 비율을 캐시 효율로 표시합니다.
 
 ```text

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ WhereMyTokens can read a running, signed-in Antigravity IDE through its local la
 - Token metadata from `GetCascadeTrajectoryGeneratorMetadata`, with bounded full-trajectory fallback
 - API-equivalent cost estimates for recognized local model metadata; unpriced models stay zero/hidden
 
+Antigravity model quota cards are percent-only by default. Enable **Antigravity quota pace** in Settings to estimate 5h/weekly pacing from reset times.
+
 Antigravity support is local-only. It does not read Google OAuth credentials, refresh tokens, Google cloud usage endpoints, credits, or offline `state.vscdb` data.
 
 ## How numbers work

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -263,6 +263,8 @@ WhereMyTokens 可以通过 `127.0.0.1` 上运行中的 Antigravity IDE local lan
 - 来自 `GetCascadeTrajectoryGeneratorMetadata` 的 token metadata，并带有有界 full-trajectory fallback
 - 对可识别的本地模型 metadata 显示 API 等价费用估算；未定价模型保持为 0 或隐藏
 
+Antigravity 模型 quota 卡片默认仅显示百分比。在 Settings 中启用 **Antigravity quota pace** 后，会根据 reset time 估算 5h/weekly pacing。
+
 Antigravity 支持保持 local-only。它不会读取 Google OAuth credential、refresh token、Google cloud usage endpoint、credits 或离线 `state.vscdb` 数据。
 
 ---

--- a/docs/superpowers/plans/2026-06-03-antigravity-quota-duration-toggle.md
+++ b/docs/superpowers/plans/2026-06-03-antigravity-quota-duration-toggle.md
@@ -1,0 +1,487 @@
+# Antigravity Quota Duration Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Based on current `main`, absorb masked Antigravity account labels, optional reset-time-derived 5h/weekly quota pace, and rich quota card title truncation without weakening `main`'s server identity, project filtering, or quota sanitization.
+
+**Architecture:** Add one canonical boolean setting, `antigravityQuotaDurationPaceEnabled`, defaulting to `false`. Antigravity quota parsing keeps current percent-only behavior unless that setting is true. Account labels use the existing `maskEmail()` utility and stay local-RPC-only. Rich quota cards truncate long provider/period titles at render time while keeping the full title in the hover tooltip.
+
+**Tech Stack:** Electron main process, TypeScript, React renderer, `electron-store` settings, Node test runner.
+
+---
+
+## File Structure
+
+- Modify `src/main/ipc.ts`: add the canonical persisted setting, normalization, and default value.
+- Modify `src/renderer/types.ts`: expose the setting in renderer `AppSettings`.
+- Modify `src/renderer/App.tsx`: add the setting to boot fallback state and state normalization.
+- Modify `src/renderer/views/SettingsView.tsx`: add a checkbox under Providers for Antigravity quota pace.
+- Modify `src/main/providers/antigravity/quota.ts`: add masked `accountLabel`; add optional duration inference behind `ctx.settings.antigravityQuotaDurationPaceEnabled`.
+- Modify `src/renderer/components/TokenStatsCard.tsx`: truncate rich card titles to 14 Unicode characters while preserving the full `title`.
+- Modify `scripts/provider-settings.test.mjs`: cover settings defaults, normalization, renderer type, and settings UI exposure.
+- Modify `scripts/antigravity-quota-parser.test.mjs`: cover default percent-only behavior and opt-in duration inference.
+- Modify `scripts/antigravity-provider-integration.test.mjs`: cover masked account label and setting-driven duration output.
+- Modify `scripts/state-readiness.test.mjs`: cover rich card title truncation source shape.
+- PRD: no PRD file was found by `rg --files --encoding utf-8 | rg -i "(^|/)(prd|.*prd.*)\\.(md|txt|docx)$|PRD"`, so no PRD update is required unless one is added before implementation.
+
+---
+
+### Task 1: Add Canonical Setting
+
+**Files:**
+- Modify: `src/main/ipc.ts`
+- Modify: `src/renderer/types.ts`
+- Modify: `src/renderer/App.tsx`
+- Modify: `src/renderer/views/SettingsView.tsx`
+- Test: `scripts/provider-settings.test.mjs`
+
+- [ ] **Step 1: Write failing settings tests**
+
+Add these assertions to `scripts/provider-settings.test.mjs` in the existing settings tests:
+
+```js
+test('Antigravity quota duration pace setting defaults off and normalizes boolean values', () => {
+  assert.equal(DEFAULT_SETTINGS.antigravityQuotaDurationPaceEnabled, false);
+  assert.equal(normalizeSettings({}).antigravityQuotaDurationPaceEnabled, false);
+  assert.equal(normalizeSettings({ antigravityQuotaDurationPaceEnabled: true }).antigravityQuotaDurationPaceEnabled, true);
+  assert.equal(normalizeSettings({ antigravityQuotaDurationPaceEnabled: false }).antigravityQuotaDurationPaceEnabled, false);
+  assert.equal(normalizeSettings({ antigravityQuotaDurationPaceEnabled: 'true' }).antigravityQuotaDurationPaceEnabled, false);
+});
+```
+
+Extend `renderer settings model exposes enabledProviders as editable state`:
+
+```js
+assert.match(types, /antigravityQuotaDurationPaceEnabled: boolean/);
+assert.match(settingsView, /'antigravityQuotaDurationPaceEnabled'/);
+assert.match(settingsView, /Antigravity quota pace/);
+```
+
+- [ ] **Step 2: Run targeted test to verify failure**
+
+Run: `npm.cmd run build:main && node --test scripts/provider-settings.test.mjs`
+
+Expected before implementation: FAIL with missing `antigravityQuotaDurationPaceEnabled` assertions.
+
+- [ ] **Step 3: Implement main-process setting schema**
+
+In `src/main/ipc.ts`, update `AppSettings`:
+
+```ts
+  quotaTargetModes: Partial<Record<string, QuotaDisplayMode>>;
+  quotaTargetOrder: string[];
+  antigravityQuotaDurationPaceEnabled: boolean;
+  compactWidgetEnabled: boolean;
+```
+
+In `normalizedSettingsPartial()` add:
+
+```ts
+  if (typeof record.antigravityQuotaDurationPaceEnabled === 'boolean') {
+    next.antigravityQuotaDurationPaceEnabled = record.antigravityQuotaDurationPaceEnabled;
+  }
+```
+
+In `DEFAULT_SETTINGS` add:
+
+```ts
+  quotaTargetModes: {},
+  quotaTargetOrder: [],
+  antigravityQuotaDurationPaceEnabled: false,
+  compactWidgetEnabled: false,
+```
+
+- [ ] **Step 4: Implement renderer setting schema and boot default**
+
+In `src/renderer/types.ts`, update `AppSettings`:
+
+```ts
+  quotaTargetModes: Partial<Record<string, QuotaDisplayMode>>;
+  quotaTargetOrder: string[];
+  antigravityQuotaDurationPaceEnabled: boolean;
+  compactWidgetEnabled: boolean;
+```
+
+In `src/renderer/App.tsx`, update `DEFAULT_STATE.settings`:
+
+```ts
+    quotaTargetModes: {},
+    quotaTargetOrder: [],
+    antigravityQuotaDurationPaceEnabled: false,
+    compactWidgetEnabled: false, compactWidgetWaitingAnimationEnabled: false, compactWidgetBounds: null,
+```
+
+In `src/renderer/App.tsx`, when normalizing incoming state settings near the existing quota target fields, add:
+
+```ts
+      antigravityQuotaDurationPaceEnabled: next.settings?.antigravityQuotaDurationPaceEnabled === true,
+```
+
+- [ ] **Step 5: Implement Settings UI checkbox**
+
+In `src/renderer/views/SettingsView.tsx`, add the setting to `EDITABLE_SETTING_KEYS` after `quotaTargetOrder`:
+
+```ts
+  'quotaTargetModes',
+  'quotaTargetOrder',
+  'antigravityQuotaDurationPaceEnabled',
+  'compactWidgetEnabled',
+```
+
+In `normalizeSettingsDraft()` add:
+
+```ts
+    antigravityQuotaDurationPaceEnabled: settings.antigravityQuotaDurationPaceEnabled === true,
+```
+
+Under the Providers section, after the provider checkbox block and before `quotaTargetOptions`, add:
+
+```tsx
+        {enabledProvidersFromSettings(s).includes('antigravity') && (
+          <div style={row}>
+            <div>
+              <div style={labelStyle}>Antigravity quota pace</div>
+              <div style={{ fontSize: 10, color: C.textMuted, marginTop: 2 }}>
+                Infer 5h or weekly pacing from reset times; off keeps Antigravity model quotas percent-only
+              </div>
+            </div>
+            <input
+              type="checkbox"
+              style={chk}
+              checked={s.antigravityQuotaDurationPaceEnabled}
+              onChange={e => setS({ ...s, antigravityQuotaDurationPaceEnabled: e.target.checked })}
+            />
+          </div>
+        )}
+```
+
+- [ ] **Step 6: Run settings test**
+
+Run: `npm.cmd run build:main && node --test scripts/provider-settings.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add src/main/ipc.ts src/renderer/types.ts src/renderer/App.tsx src/renderer/views/SettingsView.tsx scripts/provider-settings.test.mjs
+git commit -m "feat: add Antigravity quota pace setting"
+```
+
+---
+
+### Task 2: Add Masked Account Label And Optional Duration Inference
+
+**Files:**
+- Modify: `src/main/providers/antigravity/quota.ts`
+- Test: `scripts/antigravity-quota-parser.test.mjs`
+- Test: `scripts/antigravity-provider-integration.test.mjs`
+
+- [ ] **Step 1: Write failing parser tests**
+
+In `scripts/antigravity-quota-parser.test.mjs`, keep the existing default percent-only tests and add:
+
+```js
+test('Antigravity quota parser infers 5h and weekly duration only when enabled', () => {
+  const now = Date.parse('2026-06-01T00:00:00.000Z');
+  const models = parseAntigravityModelQuotas([
+    {
+      label: 'Gemini 3 Pro',
+      modelOrAlias: { model: 'MODEL_GEMINI_3_PRO' },
+      quotaInfo: { remainingFraction: 0.5, resetTime: now + 2 * 60 * 60 * 1000 },
+    },
+    {
+      label: 'Claude Opus',
+      modelOrAlias: { model: 'MODEL_CLAUDE_OPUS' },
+      quotaInfo: { remainingFraction: 0.4, resetTime: now + 6 * 60 * 60 * 1000 },
+    },
+  ], now, { inferDurationFromReset: true });
+
+  assert.equal(models[0].durationMs, 5 * 60 * 60 * 1000);
+  assert.equal(models[0].visualKind, 'pace');
+  assert.equal(models[1].durationMs, 7 * 24 * 60 * 60 * 1000);
+  assert.equal(models[1].visualKind, 'pace');
+});
+```
+
+In `scripts/antigravity-provider-integration.test.mjs`, extend the first integration test:
+
+```js
+    assert.equal(quota.accountLabel, 'pe***@example.com');
+    assert.equal(quota.models[0].durationMs, undefined);
+    assert.equal(quota.models[0].visualKind, 'percentOnly');
+```
+
+Add a second quota call in that same server block:
+
+```js
+    const quotaWithPace = await fetchAntigravityQuotaFromServers(
+      context({
+        nowMs,
+        settings: {
+          enabledProviders: ['antigravity'],
+          antigravityQuotaDurationPaceEnabled: true,
+        },
+      }),
+      [serverInfo],
+    );
+    assert.equal(quotaWithPace.models[0].durationMs, 5 * 60 * 60 * 1000);
+    assert.equal(quotaWithPace.models[0].visualKind, 'pace');
+```
+
+- [ ] **Step 2: Run targeted tests to verify failure**
+
+Run: `npm.cmd run build:main && node --test scripts/antigravity-quota-parser.test.mjs scripts/antigravity-provider-integration.test.mjs`
+
+Expected before implementation: FAIL because `parseAntigravityModelQuotas()` does not accept the option and quota snapshots do not set `accountLabel`.
+
+- [ ] **Step 3: Implement optional duration inference**
+
+In `src/main/providers/antigravity/quota.ts`, update imports:
+
+```ts
+import { maskEmail, parseTimestampMs } from './pathUtils';
+```
+
+Add constants and options near the existing helper functions:
+
+```ts
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface AntigravityQuotaParseOptions {
+  inferDurationFromReset?: boolean;
+}
+```
+
+Add helper:
+
+```ts
+function durationMsFromReset(resetMs: number | null, enabled: boolean): number | undefined {
+  if (!enabled || resetMs == null) return undefined;
+  return resetMs <= FIVE_HOURS_MS ? FIVE_HOURS_MS : WEEK_MS;
+}
+```
+
+Change `parseAntigravityModelQuotas()` signature and model construction:
+
+```ts
+export function parseAntigravityModelQuotas(
+  configs: AntigravityModelConfig[],
+  nowMs: number,
+  options: AntigravityQuotaParseOptions = {},
+): ProviderModelQuota[] {
+  return configs
+    .filter(config => !!config.quotaInfo)
+    .map((config): ProviderModelQuota | null => {
+      const remainingPct = remainingPctFromFraction(config.quotaInfo?.remainingFraction);
+      if (remainingPct == null) return null;
+      const model = config.modelOrAlias?.model || config.label || 'unknown';
+      const label = config.label || model;
+      const resetMs = resetMsFromValue(config.quotaInfo?.resetTime, nowMs);
+      const durationMs = durationMsFromReset(resetMs, options.inferDurationFromReset === true);
+      const usageModel = normalizeAntigravityModel(model, new Map([[model, label]]));
+      return {
+        model,
+        label,
+        statsWindowKey: `model.${model}`,
+        remainingPct,
+        resetMs,
+        defaultMode: defaultQuotaModeForModel(label, model),
+        usageModel,
+        visualKind: durationMs ? 'pace' : 'percentOnly',
+        cacheMetricTitle: 'Cache read / prompt tokens',
+        durationMs,
+        hideCost: !resolveAntigravityPriceForModel(usageModel, `${model} ${label}`),
+      };
+    })
+    .filter((quota): quota is ProviderModelQuota => !!quota);
+}
+```
+
+- [ ] **Step 4: Implement masked account label and setting pass-through**
+
+Change `snapshotFromStatus()`:
+
+```ts
+function snapshotFromStatus(
+  response: AntigravityUserStatusResponse,
+  nowMs: number,
+  options: AntigravityQuotaParseOptions = {},
+): ProviderQuotaSnapshot {
+  const userStatus = response.userStatus;
+  const rawConfigs = userStatus?.cascadeModelConfigData?.clientModelConfigs;
+  const configs = Array.isArray(rawConfigs)
+    ? rawConfigs.filter((config): config is AntigravityModelConfig => !!config && typeof config === 'object' && !Array.isArray(config))
+    : [];
+  return {
+    provider: 'antigravity',
+    source: 'localRpc',
+    capturedAt: nowMs,
+    accountLabel: maskEmail(userStatus?.email),
+    planName: userStatus?.planStatus?.planInfo?.planName,
+    models: parseAntigravityModelQuotas(configs, nowMs, options),
+    status: {
+      connected: true,
+      code: 'connected',
+      label: 'Connected',
+      severity: 'ok',
+    },
+  };
+}
+```
+
+In `fetchAntigravityQuotaFromServers()`, call:
+
+```ts
+        snapshot: snapshotFromStatus(status, ctx.nowMs, {
+          inferDurationFromReset: ctx.settings.antigravityQuotaDurationPaceEnabled === true,
+        }),
+```
+
+- [ ] **Step 5: Run Antigravity quota tests**
+
+Run: `npm.cmd run build:main && node --test scripts/antigravity-quota-parser.test.mjs scripts/antigravity-provider-integration.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add src/main/providers/antigravity/quota.ts scripts/antigravity-quota-parser.test.mjs scripts/antigravity-provider-integration.test.mjs
+git commit -m "feat: add Antigravity quota account and pace inference"
+```
+
+---
+
+### Task 3: Add Rich Card Title Truncation
+
+**Files:**
+- Modify: `src/renderer/components/TokenStatsCard.tsx`
+- Test: `scripts/state-readiness.test.mjs`
+
+- [ ] **Step 1: Write failing source regression test**
+
+In `scripts/state-readiness.test.mjs`, add a new test near the renderer display tests:
+
+```js
+test('rich quota card titles truncate visually while preserving full hover title', () => {
+  const source = fs.readFileSync(path.resolve('src', 'renderer', 'components', 'TokenStatsCard.tsx'), 'utf8');
+
+  assert.match(source, /function truncateTitle\(title: string, maxChars = 14\): string/);
+  assert.match(source, /const visibleTitle = truncateTitle\(displayTitle\)/);
+  assert.match(source, /title=\{displayTitle\}/);
+  assert.match(source, /\{visibleTitle\}/);
+});
+```
+
+- [ ] **Step 2: Run targeted test to verify failure**
+
+Run: `npm.cmd run build:main && node --test scripts/state-readiness.test.mjs`
+
+Expected before implementation: FAIL on missing `truncateTitle()` and `visibleTitle` patterns.
+
+- [ ] **Step 3: Implement Unicode-safe title truncation**
+
+In `src/renderer/components/TokenStatsCard.tsx`, add this helper after `formatUsagePct()`:
+
+```ts
+function truncateTitle(title: string, maxChars = 14): string {
+  const chars = Array.from(title);
+  return chars.length > maxChars ? chars.slice(0, maxChars).join('') : title;
+}
+```
+
+Inside `TokenStatsCard()`, after:
+
+```ts
+  const displayTitle = `${provider} ${period}`;
+```
+
+add:
+
+```ts
+  const visibleTitle = truncateTitle(displayTitle);
+```
+
+In the rich-card title span, replace:
+
+```tsx
+            {displayTitle}
+```
+
+with:
+
+```tsx
+            {visibleTitle}
+```
+
+Keep the existing `title={displayTitle}` prop unchanged so the full title remains available on hover.
+
+- [ ] **Step 4: Run renderer/source test**
+
+Run: `npm.cmd run build:main && node --test scripts/state-readiness.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add src/renderer/components/TokenStatsCard.tsx scripts/state-readiness.test.mjs
+git commit -m "feat: truncate rich quota card titles"
+```
+
+---
+
+### Task 4: Final Verification And Packaging Check
+
+**Files:**
+- No code changes unless a verification failure identifies a scoped bug.
+
+- [ ] **Step 1: Run focused regression suite**
+
+Run:
+
+```bash
+node --test scripts/provider-settings.test.mjs scripts/antigravity-quota-parser.test.mjs scripts/antigravity-provider-integration.test.mjs scripts/state-readiness.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run production build**
+
+Run:
+
+```bash
+npm.cmd run build
+```
+
+Expected: TypeScript and renderer build complete without errors.
+
+- [ ] **Step 3: Optional packaging only if user asks for exe**
+
+Run:
+
+```bash
+npm.cmd run dist
+```
+
+Expected: `release/WhereMyTokens 1.18.0.exe` and `release/WhereMyTokens Setup 1.18.0.exe` are rebuilt from this branch.
+
+- [ ] **Step 4: Final commit if previous tasks were squashed manually**
+
+If the implementation was done without per-task commits, create one scoped commit:
+
+```bash
+git add src/main/ipc.ts src/renderer/types.ts src/renderer/App.tsx src/renderer/views/SettingsView.tsx src/main/providers/antigravity/quota.ts src/renderer/components/TokenStatsCard.tsx scripts/provider-settings.test.mjs scripts/antigravity-quota-parser.test.mjs scripts/antigravity-provider-integration.test.mjs scripts/state-readiness.test.mjs
+git commit -m "feat: add optional Antigravity quota pacing"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: masked account label is in Task 2; optional reset-derived 5h/weekly duration is in Tasks 1 and 2; default-off behavior is in Tasks 1 and 2; rich card 14-character title truncation is in Task 3.
+- Placeholder scan: no task uses TBD, TODO, or generic "add tests" wording without concrete code and commands.
+- Type consistency: the setting name is `antigravityQuotaDurationPaceEnabled` across main IPC, renderer types, renderer default state, Settings UI, and quota parser pass-through.
+- Boundary preservation: no task removes `serverIdentity`, `projectKeys`, legacy provider migration, quota sanitize, existing tray behavior, or existing percent-only default behavior.

--- a/scripts/antigravity-provider-integration.test.mjs
+++ b/scripts/antigravity-provider-integration.test.mjs
@@ -128,13 +128,95 @@ test('Antigravity provider maps local quota and usage RPC data into WMT provider
     assert.equal(quota.provider, 'antigravity');
     assert.equal(quota.source, 'localRpc');
     assert.equal(quota.status.connected, true);
+    assert.equal(quota.accountLabel, 'pe***@example.com');
     assert.equal(quota.models[0].remainingPct, 80);
+    assert.equal(quota.models[0].durationMs, undefined);
+    assert.equal(quota.models[0].visualKind, 'percentOnly');
     assert.equal('credits' in quota, false);
     assert.equal('source' in quota.models[0], false);
+    const quotaWithPace = await fetchAntigravityQuotaFromServers(
+      context({
+        nowMs,
+        settings: {
+          enabledProviders: ['antigravity'],
+          antigravityQuotaDurationPaceEnabled: true,
+        },
+      }),
+      [serverInfo],
+    );
+    assert.equal(quotaWithPace.models[0].durationMs, 5 * 60 * 60 * 1000);
+    assert.equal(quotaWithPace.models[0].visualKind, 'pace');
     assert.equal(usage.summaries.has(summaryKey(serverInfo, 'c1')), true);
     assert.equal(usage.ledgerSources.length, 1);
     assert.equal(usage.scannedSources, 1);
   });
+});
+
+test('Antigravity quota selection prefers the server with the newest cascade activity', async () => {
+  const nowMs = Date.parse('2026-06-01T12:00:00.000Z');
+  const handlerFor = ({ remainingFraction, resetMs, newestMs }) => (req, res) => {
+    if (req.url.endsWith('/GetUserStatus')) {
+      sendJson(res, {
+        userStatus: {
+          cascadeModelConfigData: {
+            clientModelConfigs: [
+              {
+                label: 'Gemini 3 Pro',
+                modelOrAlias: { model: 'MODEL_GEMINI_3_PRO' },
+                quotaInfo: { remainingFraction, resetTime: nowMs + resetMs },
+              },
+            ],
+          },
+        },
+      });
+      return;
+    }
+    if (req.url.endsWith('/GetAllCascadeTrajectories')) {
+      sendJson(res, {
+        trajectorySummaries: {
+          c1: {
+            lastModifiedTime: new Date(newestMs).toISOString(),
+            stepCount: 1,
+            status: 'CASCADE_RUN_STATUS_RUNNING',
+          },
+        },
+      });
+      return;
+    }
+    sendJson(res, {});
+  };
+
+  await withAntigravityServer(
+    handlerFor({
+      remainingFraction: 1,
+      resetMs: 4 * 60 * 60 * 1000,
+      newestMs: nowMs - 60 * 60 * 1000,
+    }),
+    async olderServer => {
+      await withAntigravityServer(
+        handlerFor({
+          remainingFraction: 0.2,
+          resetMs: 6 * 60 * 60 * 1000,
+          newestMs: nowMs - 60 * 1000,
+        }),
+        async newerServer => {
+          const quota = await fetchAntigravityQuotaFromServers(
+            context({
+              nowMs,
+              settings: {
+                enabledProviders: ['antigravity'],
+                antigravityQuotaDurationPaceEnabled: true,
+              },
+            }),
+            [olderServer, newerServer],
+          );
+
+          assert.equal(quota.models[0].remainingPct, 20);
+          assert.equal(quota.models[0].durationMs, 7 * 24 * 60 * 60 * 1000);
+        },
+      );
+    },
+  );
 });
 
 test('Antigravity usage scan returns partial near deadline instead of waiting for slow GM RPC timeout', async () => {

--- a/scripts/antigravity-provider-integration.test.mjs
+++ b/scripts/antigravity-provider-integration.test.mjs
@@ -129,7 +129,11 @@ test('Antigravity provider maps local quota and usage RPC data into WMT provider
     assert.equal(quota.source, 'localRpc');
     assert.equal(quota.status.connected, true);
     assert.equal(quota.accountLabel, 'pe***@example.com');
+    assert.equal(quota.accountTooltip, 'pe***@example.com');
+    assert.equal(quota.accountTooltip.includes('person@example.com'), false);
     assert.equal(quota.models[0].remainingPct, 80);
+    assert.equal(quota.models[0].usageModel, 'Gemini 3 Pro');
+    assert.equal(quota.models[0].statsWindowKey, 'model.MODEL_GEMINI_3_PRO');
     assert.equal(quota.models[0].durationMs, undefined);
     assert.equal(quota.models[0].visualKind, 'percentOnly');
     assert.equal('credits' in quota, false);

--- a/scripts/antigravity-quota-parser.test.mjs
+++ b/scripts/antigravity-quota-parser.test.mjs
@@ -56,3 +56,47 @@ test('Antigravity quota parser does not infer a quota duration from reset time a
   assert.equal(model.visualKind, 'percentOnly');
   assert.equal(model.durationMs, undefined);
 });
+
+test('Antigravity quota parser infers 5h and weekly duration only when enabled', () => {
+  const now = Date.parse('2026-06-01T00:00:00.000Z');
+  const models = parseAntigravityModelQuotas([
+    {
+      label: 'Gemini 3 Pro',
+      modelOrAlias: { model: 'MODEL_GEMINI_3_PRO' },
+      quotaInfo: { remainingFraction: 0.5, resetTime: now + 2 * 60 * 60 * 1000 },
+    },
+    {
+      label: 'Claude Opus',
+      modelOrAlias: { model: 'MODEL_CLAUDE_OPUS' },
+      quotaInfo: { remainingFraction: 0.4, resetTime: now + 6 * 60 * 60 * 1000 },
+    },
+  ], now, { inferDurationFromReset: true });
+
+  assert.equal(models[0].durationMs, 5 * 60 * 60 * 1000);
+  assert.equal(models[0].visualKind, 'pace');
+  assert.equal(models[1].durationMs, 7 * 24 * 60 * 60 * 1000);
+  assert.equal(models[1].visualKind, 'pace');
+});
+
+test('Antigravity quota parser does not infer duration for elapsed reset windows', () => {
+  const now = Date.parse('2026-06-01T00:00:00.000Z');
+  const models = parseAntigravityModelQuotas([
+    {
+      label: 'Gemini 3 Pro',
+      modelOrAlias: { model: 'MODEL_GEMINI_3_PRO' },
+      quotaInfo: { remainingFraction: 0.5, resetTime: now },
+    },
+    {
+      label: 'Claude Opus',
+      modelOrAlias: { model: 'MODEL_CLAUDE_OPUS' },
+      quotaInfo: { remainingFraction: 0.4, resetTime: now - 60 * 1000 },
+    },
+  ], now, { inferDurationFromReset: true });
+
+  assert.equal(models[0].resetMs, 0);
+  assert.equal(models[0].durationMs, undefined);
+  assert.equal(models[0].visualKind, 'percentOnly');
+  assert.equal(models[1].resetMs, 0);
+  assert.equal(models[1].durationMs, undefined);
+  assert.equal(models[1].visualKind, 'percentOnly');
+});

--- a/scripts/provider-settings.test.mjs
+++ b/scripts/provider-settings.test.mjs
@@ -74,6 +74,14 @@ test('settings normalize quota target display modes by target id', () => {
   assert.deepEqual(DEFAULT_SETTINGS.quotaTargetOrder, []);
 });
 
+test('Antigravity quota duration pace setting defaults off and normalizes boolean values', () => {
+  assert.equal(DEFAULT_SETTINGS.antigravityQuotaDurationPaceEnabled, false);
+  assert.equal(normalizeSettings({}).antigravityQuotaDurationPaceEnabled, false);
+  assert.equal(normalizeSettings({ antigravityQuotaDurationPaceEnabled: true }).antigravityQuotaDurationPaceEnabled, true);
+  assert.equal(normalizeSettings({ antigravityQuotaDurationPaceEnabled: false }).antigravityQuotaDurationPaceEnabled, false);
+  assert.equal(normalizeSettings({ antigravityQuotaDurationPaceEnabled: 'true' }).antigravityQuotaDurationPaceEnabled, false);
+});
+
 test('renderer settings model exposes enabledProviders as editable state', () => {
   const types = fs.readFileSync('src/renderer/types.ts', 'utf8');
   const settingsView = fs.readFileSync('src/renderer/views/SettingsView.tsx', 'utf8');
@@ -81,10 +89,13 @@ test('renderer settings model exposes enabledProviders as editable state', () =>
   assert.match(types, /enabledProviders: Array<'claude' \| 'codex' \| 'antigravity'>/);
   assert.match(types, /quotaTargetModes: Partial<Record<string, QuotaDisplayMode>>/);
   assert.match(types, /quotaTargetOrder: string\[\]/);
+  assert.match(types, /antigravityQuotaDurationPaceEnabled: boolean/);
   assert.doesNotMatch(types, /provider: 'claude' \| 'codex' \| 'both'/);
   assert.match(settingsView, /'enabledProviders'/);
   assert.match(settingsView, /'quotaTargetModes'/);
   assert.match(settingsView, /'quotaTargetOrder'/);
+  assert.match(settingsView, /'antigravityQuotaDurationPaceEnabled'/);
+  assert.match(settingsView, /Antigravity quota pace/);
   assert.doesNotMatch(settingsView, /'plan'/);
   assert.doesNotMatch(settingsView, /'provider'/);
 });

--- a/scripts/provider-usage-shape.test.mjs
+++ b/scripts/provider-usage-shape.test.mjs
@@ -359,6 +359,54 @@ test('provider reset hints apply to generic provider windows', () => {
   assert.equal(ledger.byProvider.antigravity.windows.week.totalTokens, 300);
 });
 
+test('timed model quota windows count overlapping model names once', () => {
+  const now = Date.parse('2026-05-25T12:00:00.000Z');
+  const quotas = {
+    antigravity: {
+      provider: 'antigravity',
+      source: 'localRpc',
+      capturedAt: now,
+      models: [
+        {
+          model: 'MODEL_GEMINI_3_PRO',
+          label: 'Gemini 3 Pro',
+          usageModel: 'Gemini 3 Pro',
+          remainingPct: 80,
+          resetMs: 4 * 60 * 60 * 1000,
+          durationMs: 5 * 60 * 60 * 1000,
+        },
+        {
+          model: 'MODEL_GEMINI_3_PRO_PREVIEW',
+          label: 'Gemini 3 Pro Preview',
+          usageModel: 'Gemini 3 Pro Preview',
+          remainingPct: 70,
+          resetMs: 4 * 60 * 60 * 1000,
+          durationMs: 5 * 60 * 60 * 1000,
+        },
+      ],
+    },
+  };
+  const originalNow = Date.now;
+  Date.now = () => now;
+  try {
+    const summaryUsage = computeUsage([
+      summary('antigravity', [
+        usageEntry('antigravity', 'Gemini 3 Pro Preview', 300, now - 60_000),
+      ]),
+    ], {}, undefined, quotas);
+
+    assert.equal(summaryUsage.byProvider.antigravity.windows.h5.totalTokens, 300);
+  } finally {
+    Date.now = originalNow;
+  }
+
+  const snapshot = emptyUsageLedgerSnapshot();
+  snapshot.minuteRecent[minuteKey(now - 60_000, 'antigravity', 'Gemini 3 Pro Preview')] = agg(300);
+  const ledger = computeUsageFromLedger(snapshot, {}, now, undefined, quotas);
+
+  assert.equal(ledger.byProvider.antigravity.windows.h5.totalTokens, 300);
+});
+
 test('Antigravity cache efficiency includes uncached prompt tokens instead of reporting all cache reads as 100%', () => {
   const now = Date.now();
   const promptStats = {

--- a/scripts/quota-display-groups.test.mjs
+++ b/scripts/quota-display-groups.test.mjs
@@ -350,6 +350,60 @@ test('model fallback quota rows attach matching model usage stats', async () => 
   assert.equal(models.richGroups[0].badges.some(badge => badge.key === 'cost.total'), false);
 });
 
+test('pace model quota rows fall back to duration bucket stats when dedicated model window is empty', async () => {
+  const { buildQuotaDisplayModels } = await loadQuotaDisplayModels();
+  const options = baseOptions({
+    enabledProviders: ['antigravity'],
+  });
+  options.usage.modelWindows = {
+    antigravity: {
+      windows: {
+        'model.MODEL_GEMINI_3_PRO': {},
+        h5: {
+          'Gemini 3 Pro': {
+            inputTokens: 1000,
+            outputTokens: 2000,
+            cacheCreationTokens: 3000,
+            cacheReadTokens: 6345,
+            totalTokens: 12_345,
+            costUSD: 0.456,
+            requestCount: 3,
+            cacheEfficiency: 67,
+            cacheSavingsUSD: 0.123,
+          },
+        },
+      },
+    },
+  };
+  options.providerQuotas = {
+    antigravity: {
+      provider: 'antigravity',
+      source: 'localRpc',
+      capturedAt: Date.now(),
+      status: { connected: true, code: 'connected' },
+      models: [
+        {
+          model: 'MODEL_GEMINI_3_PRO',
+          label: 'Gemini 3 Pro',
+          usageModel: 'Gemini 3 Pro',
+          remainingPct: 42,
+          defaultMode: 'rich',
+          visualKind: 'pace',
+          durationMs: 5 * 60 * 60 * 1000,
+          statsWindowKey: 'model.MODEL_GEMINI_3_PRO',
+          hideCost: false,
+        },
+      ],
+    },
+  };
+
+  const models = buildQuotaDisplayModels(options);
+  const row = models.richGroups[0].rows[0];
+
+  assert.equal(row.stats.totalTokens, 12_345);
+  assert.equal(row.stats.costUSD, 0.456);
+});
+
 test('model fallback quota rows preserve precomputed cache efficiency from usage windows', async () => {
   const { buildQuotaDisplayModels } = await loadQuotaDisplayModels();
   const options = baseOptions({

--- a/scripts/stability-regressions.test.mjs
+++ b/scripts/stability-regressions.test.mjs
@@ -1345,7 +1345,8 @@ test('foreground and manual refresh use budgeted ledger-backed history scans', (
   assert.match(heavyBody, /const summaryForce = force && hasExcludedProjects/);
   assert.match(heavyBody, /const summaryIncludeFullHistory = includeFullHistory && hasExcludedProjects/);
   assert.match(heavyBody, /this\.loadProviderSummaries\(summaryForce, effectiveScanBudgetMs, priorityFiles, summaryIncludeFullHistory\)/);
-  assert.match(heavyBody, /const partialHistoryScan = ledgerRefresh\.partial \|\| loaded\.partial/);
+  assert.match(heavyBody, /const summaryPartial = loaded\.scanPartial \|\| \(hasExcludedProjects && loaded\.sourceListPartial\)/);
+  assert.match(heavyBody, /const partialHistoryScan = ledgerRefresh\.partial \|\| summaryPartial/);
   assert.match(heavyBody, /const nextSummaries = partialHistoryScan && initialRefreshDone/);
   assert.match(heavyBody, /new Map\(\[\.\.\.this\.summaries, \.\.\.loaded\.summaries\]\)/);
   assert.match(heavyBody, /this\.mergeCodexRateLimits\(this\.codexRateLimits, loaded\.codexRateLimits \?\? undefined\)/);

--- a/scripts/startup-state-snapshot.test.mjs
+++ b/scripts/startup-state-snapshot.test.mjs
@@ -180,6 +180,20 @@ test('StateManager sanitizes restored provider quota snapshots', () => {
         usage: { raw: true },
         authMtimeMs: 123,
       },
+      antigravity: {
+        provider: 'antigravity',
+        source: 'localRpc',
+        capturedAt: now,
+        accountLabel: 'pe***@example.com',
+        accountTooltip: 'person@example.com',
+        models: [{
+          model: 'MODEL_GEMINI_3_PRO',
+          label: 'Gemini 3 Pro',
+          usageModel: 'Gemini 3 Pro',
+          statsWindowKey: 'model.MODEL_GEMINI_3_PRO',
+          remainingPct: 42,
+        }],
+      },
     },
   }, now);
 
@@ -192,6 +206,10 @@ test('StateManager sanitizes restored provider quota snapshots', () => {
   assert.equal(codexQuota.models, undefined);
   assert.equal('usage' in codexQuota, false);
   assert.equal('authMtimeMs' in codexQuota, false);
+  const antigravityQuota = manager.getState().providerQuotas.antigravity;
+  assert.equal(antigravityQuota.accountTooltip, 'pe***@example.com');
+  assert.equal(antigravityQuota.models[0].usageModel, 'Gemini 3 Pro');
+  assert.equal(antigravityQuota.models[0].statsWindowKey, 'model.MODEL_GEMINI_3_PRO');
 });
 
 test('startup snapshot normalizer rejects malformed session lists', () => {

--- a/scripts/state-readiness.test.mjs
+++ b/scripts/state-readiness.test.mjs
@@ -100,7 +100,7 @@ test('renderer mutes cached usage text and shows soft loading states', () => {
   assert.match(source, /LimitStatusBar/);
 });
 
-test('rich quota card title uses CSS ellipsis and keeps full title tooltip', async () => {
+test('rich quota card title truncates text and keeps full title tooltip', async () => {
   const TokenStatsCard = await importRendererComponent(
     path.resolve('src', 'renderer', 'components', 'TokenStatsCard.tsx'),
     'TokenStatsCard',
@@ -139,7 +139,7 @@ test('rich quota card title uses CSS ellipsis and keeps full title tooltip', asy
   assert.ok(titleSpan, html);
   const titleText = html.match(new RegExp(`<span title="${displayTitle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}" style="[^"]+">([^<]+)`));
   assert.ok(titleText, html);
-  assert.equal(titleText[1], displayTitle);
+  assert.equal(titleText[1], 'Gemini 3.1 Pro');
   assert.match(titleSpan[1], /flex:1 1 auto/);
   assert.match(titleSpan[1], /overflow:hidden/);
   assert.match(titleSpan[1], /text-overflow:ellipsis/);
@@ -395,6 +395,14 @@ test('header today cache metric uses today aggregates instead of the 5-hour wind
 
   assert.match(source, /const cacheEff = isAll \? usage\.allTimeAvgCacheEfficiency : usage\.todayCacheEfficiency/);
   assert.match(source, /const saved = isAll \? usage\.allTimeSavedUSD : usage\.todayCacheSavingsUSD/);
+});
+
+test('rich quota card titles truncate visually while preserving full hover title', () => {
+  const source = fs.readFileSync(path.resolve('src', 'renderer', 'components', 'TokenStatsCard.tsx'), 'utf8');
+
+  assert.match(source, /title=\{displayTitle\}/);
+  assert.doesNotMatch(source, /title=\{visibleTitle\}/);
+  assert.doesNotMatch(source, />\{displayTitle\}<\/span>/);
 });
 
 test('tray and header status derive provider data from enabled providers', () => {

--- a/scripts/state-readiness.test.mjs
+++ b/scripts/state-readiness.test.mjs
@@ -100,7 +100,7 @@ test('renderer mutes cached usage text and shows soft loading states', () => {
   assert.match(source, /LimitStatusBar/);
 });
 
-test('rich quota card title truncates text and keeps full title tooltip', async () => {
+test('rich quota card title uses CSS ellipsis and keeps full title tooltip', async () => {
   const TokenStatsCard = await importRendererComponent(
     path.resolve('src', 'renderer', 'components', 'TokenStatsCard.tsx'),
     'TokenStatsCard',
@@ -139,7 +139,7 @@ test('rich quota card title truncates text and keeps full title tooltip', async 
   assert.ok(titleSpan, html);
   const titleText = html.match(new RegExp(`<span title="${displayTitle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}" style="[^"]+">([^<]+)`));
   assert.ok(titleText, html);
-  assert.equal(titleText[1], 'Gemini 3.1 Pro');
+  assert.equal(titleText[1], displayTitle);
   assert.match(titleSpan[1], /flex:1 1 auto/);
   assert.match(titleSpan[1], /overflow:hidden/);
   assert.match(titleSpan[1], /text-overflow:ellipsis/);
@@ -400,9 +400,10 @@ test('header today cache metric uses today aggregates instead of the 5-hour wind
 test('rich quota card titles truncate visually while preserving full hover title', () => {
   const source = fs.readFileSync(path.resolve('src', 'renderer', 'components', 'TokenStatsCard.tsx'), 'utf8');
 
-  assert.match(source, /title=\{displayTitle\}/);
-  assert.doesNotMatch(source, /title=\{visibleTitle\}/);
-  assert.doesNotMatch(source, />\{displayTitle\}<\/span>/);
+  assert.match(source, /title=\{displayTitleTooltip\}/);
+  assert.doesNotMatch(source, /visibleTitle/);
+  assert.doesNotMatch(source, /truncateTitle/);
+  assert.match(source, /\{displayTitle\}/);
 });
 
 test('tray and header status derive provider data from enabled providers', () => {
@@ -434,6 +435,25 @@ test('startup refresh uses lightweight session bootstrapping and API status labe
   assert.match(rendererSource, /apiStatusLabel/);
   assert.match(rendererSource, /formatWarmupStatus/);
   assert.match(rendererSource, /resetLabel=\{card\.visualKind === 'percentOnly' \? undefined : card\.quota\.resetLabel\}/);
+});
+
+test('history warmup ignores recent summary truncation but keeps real partial scans', () => {
+  const source = fs.readFileSync(path.resolve('src', 'main', 'stateManager.ts'), 'utf8');
+
+  assert.match(source, /summaryPartial = loaded\.scanPartial \|\| \(hasExcludedProjects && loaded\.sourceListPartial\)/);
+  assert.match(source, /partialHistoryScan = ledgerRefresh\.partial \|\| summaryPartial/);
+  assert.doesNotMatch(source, /partialHistoryScan = effectiveScanBudgetMs !== null/);
+  assert.match(source, /sourceListPartial/);
+  assert.match(source, /scanPartial/);
+});
+
+test('Antigravity quota pace setting triggers quota refresh on save', () => {
+  const source = fs.readFileSync(path.resolve('src', 'main', 'stateManager.ts'), 'utf8');
+
+  assert.match(source, /quotaAffectingSettingsChanged/);
+  assert.match(source, /antigravityQuotaDurationPaceEnabled/);
+  assert.match(source, /quotaSettingsChanged && this\.enabledProviderSet\(settings\)\.has\('antigravity'\)/);
+  assert.match(source, /force: true/);
 });
 
 test('README release blocks stay compact and screenshots are full width', () => {

--- a/scripts/usage-ledger-aggregates.test.mjs
+++ b/scripts/usage-ledger-aggregates.test.mjs
@@ -2,18 +2,21 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import aggregates from '../dist/main/usageLedgerAggregates.js';
+import usageLedgerUsage from '../dist/main/usageLedgerUsage.js';
 import types from '../dist/main/usageLedgerTypes.js';
 
 const {
   addUsageAggregate,
   subtractUsageAggregate,
   emptyUsageAggregate,
+  emptyUsageLedgerSnapshot,
   minuteKey,
   hourProviderKey,
   dayModelKey,
   monthModelKey,
   compactUsageLedgerSnapshot,
 } = aggregates;
+const { computeUsageFromLedger } = usageLedgerUsage;
 const { USAGE_LEDGER_SCHEMA_VERSION } = types;
 
 test('usage aggregate add and subtract preserve all token fields', () => {
@@ -55,6 +58,49 @@ test('usage ledger key builders are stable strings', () => {
   assert.equal(hourProviderKey(1710003661000, 'codex'), '1710003600000|codex');
   assert.equal(dayModelKey('2026-05-25', 'codex', 'GPT-5-CODEX'), '2026-05-25|codex|GPT-5-CODEX');
   assert.equal(monthModelKey('2026-05-25', 'claude', 'claude-sonnet-4'), '2026-05|claude|claude-sonnet-4');
+});
+
+test('pace model quota targets populate duration bucket model windows', () => {
+  const now = Date.parse('2026-06-01T04:00:00Z');
+  const snapshot = emptyUsageLedgerSnapshot();
+  snapshot.minuteRecent[minuteKey(now - 60_000, 'antigravity', 'Gemini 3 Pro')] = {
+    requestCount: 1,
+    inputTokens: 1000,
+    outputTokens: 2000,
+    cacheCreationTokens: 3000,
+    cacheReadTokens: 4000,
+    totalTokens: 10_000,
+    costUSD: 0.1,
+    cacheSavingsUSD: 0.2,
+  };
+
+  const usage = computeUsageFromLedger(
+    snapshot,
+    {},
+    now,
+    new Set(['antigravity']),
+    {
+      antigravity: {
+        provider: 'antigravity',
+        source: 'localRpc',
+        capturedAt: now,
+        status: { connected: true, code: 'connected' },
+        models: [{
+          model: 'MODEL_GEMINI_3_PRO',
+          label: 'Gemini 3 Pro',
+          usageModel: 'Gemini 3 Pro',
+          remainingPct: 42,
+          defaultMode: 'rich',
+          visualKind: 'pace',
+          durationMs: 5 * 60 * 60 * 1000,
+          resetMs: 4 * 60 * 60 * 1000,
+          statsWindowKey: 'model.MODEL_GEMINI_3_PRO',
+        }],
+      },
+    },
+  );
+
+  assert.equal(usage.modelWindows.antigravity.windows.h5['Gemini 3 Pro'].totalTokens, 10_000);
 });
 
 test('compaction removes expired minute, request index, hourly, daily, and source repair rows', () => {

--- a/scripts/usage-ledger-state.test.mjs
+++ b/scripts/usage-ledger-state.test.mjs
@@ -230,11 +230,16 @@ test('provider changes refresh recent summaries without clearing the JSONL cache
   const settingsMatch = src.match(/applySettingsChange\(\) \{([\s\S]*?)\n  private async logMemorySnapshot/);
   assert.ok(settingsMatch);
   const settingsBody = settingsMatch[1];
+  const providerStart = settingsBody.indexOf('if (providerChanged) {');
+  const providerReturn = settingsBody.indexOf('      return;', providerStart);
+  assert.notEqual(providerStart, -1);
+  assert.notEqual(providerReturn, -1);
+  const providerBranch = settingsBody.slice(providerStart, providerReturn);
   assert.doesNotMatch(settingsBody, /jsonlCache\.clearAll/);
   assert.match(settingsBody, /reason: 'settings'/);
   assert.match(settingsBody, /includeFullHistory: true/);
   assert.match(settingsBody, /scanBudgetMs: StateManager\.FOREGROUND_SCAN_BUDGET_MS/);
-  assert.doesNotMatch(settingsBody, /reason: 'settings'[\s\S]*force: true/);
+  assert.doesNotMatch(providerBranch, /force: true/);
 });
 
 test('history warmup imports ledger sources instead of expanding summary scans to full history', () => {

--- a/scripts/usage-ledger-usage.test.mjs
+++ b/scripts/usage-ledger-usage.test.mjs
@@ -205,7 +205,7 @@ test('ledger usage query exposes cached Antigravity model window stats', () => {
   };
 
   const usage = computeUsageFromLedger(snapshot, {}, now, undefined, providerQuotas);
-  const modelWindow = usage.modelWindows.antigravity.windows['model.gemini-3-pro-high']['Gemini 3 Pro'];
+  const modelWindow = usage.modelWindows.antigravity.windows.h5['Gemini 3 Pro'];
 
   assert.equal(modelWindow.inputTokens, 100);
   assert.equal(modelWindow.outputTokens, 20);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -41,6 +41,7 @@ export interface AppSettings {
   excludedProjects: string[];
   quotaTargetModes: Partial<Record<string, QuotaDisplayMode>>;
   quotaTargetOrder: string[];
+  antigravityQuotaDurationPaceEnabled: boolean;
   compactWidgetEnabled: boolean;
   compactWidgetWaitingAnimationEnabled: boolean;
   compactWidgetBounds: CompactWidgetBounds | null;
@@ -200,6 +201,9 @@ function normalizedSettingsPartial(partial: unknown): Partial<AppSettings> {
     const quotaTargetOrder = normalizeQuotaTargetOrder(record.quotaTargetOrder);
     if (quotaTargetOrder) next.quotaTargetOrder = quotaTargetOrder;
   }
+  if (typeof record.antigravityQuotaDurationPaceEnabled === 'boolean') {
+    next.antigravityQuotaDurationPaceEnabled = record.antigravityQuotaDurationPaceEnabled;
+  }
   if (typeof record.compactWidgetEnabled === 'boolean') next.compactWidgetEnabled = record.compactWidgetEnabled;
   if (typeof record.compactWidgetWaitingAnimationEnabled === 'boolean') next.compactWidgetWaitingAnimationEnabled = record.compactWidgetWaitingAnimationEnabled;
   if (Object.prototype.hasOwnProperty.call(record, 'compactWidgetBounds')) {
@@ -243,6 +247,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   excludedProjects: [],
   quotaTargetModes: {},
   quotaTargetOrder: [],
+  antigravityQuotaDurationPaceEnabled: false,
   compactWidgetEnabled: false,
   compactWidgetWaitingAnimationEnabled: false,
   compactWidgetBounds: null,

--- a/src/main/providers/antigravity/quota.ts
+++ b/src/main/providers/antigravity/quota.ts
@@ -119,12 +119,13 @@ function snapshotFromStatus(
   const accountEmail = typeof userStatus?.email === 'string' && userStatus.email.trim().length > 0
     ? userStatus.email.trim()
     : undefined;
+  const accountLabel = maskEmail(accountEmail);
   return {
     provider: 'antigravity',
     source: 'localRpc',
     capturedAt: nowMs,
-    accountLabel: maskEmail(accountEmail),
-    accountTooltip: accountEmail,
+    accountLabel,
+    accountTooltip: accountLabel,
     planName: userStatus?.planStatus?.planInfo?.planName,
     models: parseAntigravityModelQuotas(configs, nowMs, options),
     status: {

--- a/src/main/providers/antigravity/quota.ts
+++ b/src/main/providers/antigravity/quota.ts
@@ -4,7 +4,7 @@ import type {
   ProviderQuotaSnapshot,
 } from '../types';
 import { defaultQuotaModeForModel, normalizeAntigravityModel } from './models';
-import { parseTimestampMs } from './pathUtils';
+import { maskEmail, parseTimestampMs } from './pathUtils';
 import { resolveAntigravityPriceForModel } from './pricing';
 import { findAntigravityServersCached, getTrajectorySummariesCached, getUserStatusCached } from './runtimeCache';
 import type {
@@ -13,6 +13,13 @@ import type {
   AntigravityTrajectorySummariesResponse,
   AntigravityUserStatusResponse,
 } from './types';
+
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface AntigravityQuotaParseOptions {
+  inferDurationFromReset?: boolean;
+}
 
 function deadlineMs(ctx: ProviderContext): number {
   return Date.now() + Math.min(ctx.scanBudgetMs ?? 8_000, 8_000);
@@ -37,9 +44,15 @@ function resetMsFromValue(value: unknown, nowMs: number): number | null {
   return Number.isFinite(parsed) ? Math.max(0, parsed - nowMs) : null;
 }
 
+function durationMsFromReset(resetMs: number | null, enabled: boolean): number | undefined {
+  if (!enabled || resetMs == null || resetMs <= 0) return undefined;
+  return resetMs <= FIVE_HOURS_MS ? FIVE_HOURS_MS : WEEK_MS;
+}
+
 export function parseAntigravityModelQuotas(
   configs: AntigravityModelConfig[],
   nowMs: number,
+  options: AntigravityQuotaParseOptions = {},
 ): ProviderModelQuota[] {
   return configs
     .filter(config => !!config.quotaInfo)
@@ -49,6 +62,7 @@ export function parseAntigravityModelQuotas(
       const model = config.modelOrAlias?.model || config.label || 'unknown';
       const label = config.label || model;
       const resetMs = resetMsFromValue(config.quotaInfo?.resetTime, nowMs);
+      const durationMs = durationMsFromReset(resetMs, options.inferDurationFromReset === true);
       const usageModel = normalizeAntigravityModel(model, new Map([[model, label]]));
       return {
         model,
@@ -58,8 +72,9 @@ export function parseAntigravityModelQuotas(
         resetMs,
         defaultMode: defaultQuotaModeForModel(label, model),
         usageModel,
-        visualKind: 'percentOnly',
+        visualKind: durationMs ? 'pace' : 'percentOnly',
         cacheMetricTitle: 'Cache read / prompt tokens',
+        durationMs,
         hideCost: !resolveAntigravityPriceForModel(usageModel, `${model} ${label}`),
       };
     })
@@ -86,23 +101,32 @@ interface CandidateQuota {
 
 function candidateScore(candidate: CandidateQuota): number {
   let score = 0;
-  if (candidate.newestCascadeMs > 0) score += Math.min(candidate.newestCascadeMs / 1000, 9_000_000);
+  if (candidate.newestCascadeMs > 0) score += candidate.newestCascadeMs;
   if (candidate.server.processStartedAtMs) score += candidate.server.processStartedAtMs / 10_000;
   return score;
 }
 
-function snapshotFromStatus(response: AntigravityUserStatusResponse, nowMs: number): ProviderQuotaSnapshot {
+function snapshotFromStatus(
+  response: AntigravityUserStatusResponse,
+  nowMs: number,
+  options: AntigravityQuotaParseOptions = {},
+): ProviderQuotaSnapshot {
   const userStatus = response.userStatus;
   const rawConfigs = userStatus?.cascadeModelConfigData?.clientModelConfigs;
   const configs = Array.isArray(rawConfigs)
     ? rawConfigs.filter((config): config is AntigravityModelConfig => !!config && typeof config === 'object' && !Array.isArray(config))
     : [];
+  const accountEmail = typeof userStatus?.email === 'string' && userStatus.email.trim().length > 0
+    ? userStatus.email.trim()
+    : undefined;
   return {
     provider: 'antigravity',
     source: 'localRpc',
     capturedAt: nowMs,
+    accountLabel: maskEmail(accountEmail),
+    accountTooltip: accountEmail,
     planName: userStatus?.planStatus?.planInfo?.planName,
-    models: parseAntigravityModelQuotas(configs, nowMs),
+    models: parseAntigravityModelQuotas(configs, nowMs, options),
     status: {
       connected: true,
       code: 'connected',
@@ -154,7 +178,9 @@ export async function fetchAntigravityQuotaFromServers(
         : await getTrajectorySummariesCached(server, ctx.nowMs, remainingTimeoutMs(stopAt));
       candidates.push({
         server,
-        snapshot: snapshotFromStatus(status, ctx.nowMs),
+        snapshot: snapshotFromStatus(status, ctx.nowMs, {
+          inferDurationFromReset: ctx.settings.antigravityQuotaDurationPaceEnabled === true,
+        }),
         newestCascadeMs: newestCascadeMs(trajectories),
       });
     } catch {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -138,6 +138,7 @@ export interface ProviderQuotaSnapshot {
   source: 'api' | 'statusLine' | 'localLog' | 'localRpc' | 'cache';
   capturedAt: number;
   accountLabel?: string;
+  accountTooltip?: string;
   planName?: string;
   windows?: Record<string, ProviderQuotaWindow>;
   models?: ProviderModelQuota[];

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -460,6 +460,7 @@ function sanitizeProviderQuotaSnapshot(provider: ProviderId, value: unknown): Pr
     source: quotaSource(record.source),
     capturedAt: finiteQuotaNumber(record.capturedAt) ?? 0,
     accountLabel: quotaString(record.accountLabel),
+    accountTooltip: quotaString(record.accountTooltip),
     planName: quotaString(record.planName),
     windows: sanitizeQuotaWindows(record.windows),
     models: sanitizeProviderModels(record.models),
@@ -2035,7 +2036,8 @@ export class StateManager {
       this.startupFreshComplete = true;
       this.jsonlCache.flushPersisted();
       const totalScannedFiles = loaded.scannedFiles + ledgerRefresh.scannedFiles;
-      const partialHistoryScan = ledgerRefresh.partial || loaded.partial;
+    const partialHistoryScan = effectiveScanBudgetMs !== null
+      && (ledgerRefresh.partial || (hasExcludedProjects && loaded.partial));
       const nextSummaries = partialHistoryScan && initialRefreshDone
         ? new Map([...this.summaries, ...loaded.summaries])
         : loaded.summaries;

--- a/src/main/stateManager.ts
+++ b/src/main/stateManager.ts
@@ -426,6 +426,8 @@ function sanitizeProviderModelQuota(value: unknown): ProviderModelQuota | null {
   return {
     model,
     label,
+    usageModel: quotaString(record.usageModel),
+    statsWindowKey: quotaString(record.statsWindowKey),
     remainingPct: Math.max(0, Math.min(100, finiteQuotaNumber(record.remainingPct) ?? 0)),
     resetMs: finiteQuotaNumber(record.resetMs) ?? (record.resetMs === null ? null : undefined),
     groupKey: quotaString(record.groupKey),
@@ -460,7 +462,7 @@ function sanitizeProviderQuotaSnapshot(provider: ProviderId, value: unknown): Pr
     source: quotaSource(record.source),
     capturedAt: finiteQuotaNumber(record.capturedAt) ?? 0,
     accountLabel: quotaString(record.accountLabel),
-    accountTooltip: quotaString(record.accountTooltip),
+    accountTooltip: quotaString(record.accountLabel),
     planName: quotaString(record.planName),
     windows: sanitizeQuotaWindows(record.windows),
     models: sanitizeProviderModels(record.models),
@@ -795,6 +797,10 @@ export class StateManager {
     const previousProviders = this.enabledProviderSet(previous);
     if (nextProviders.size !== previousProviders.size) return true;
     return [...nextProviders].some(provider => !previousProviders.has(provider));
+  }
+
+  private quotaAffectingSettingsChanged(next: AppSettings, previous: AppSettings): boolean {
+    return next.antigravityQuotaDurationPaceEnabled !== previous.antigravityQuotaDurationPaceEnabled;
   }
 
   private sourceBackedProviders(settings: AppSettings): SourceBackedProviderAdapter[] {
@@ -2036,8 +2042,8 @@ export class StateManager {
       this.startupFreshComplete = true;
       this.jsonlCache.flushPersisted();
       const totalScannedFiles = loaded.scannedFiles + ledgerRefresh.scannedFiles;
-    const partialHistoryScan = effectiveScanBudgetMs !== null
-      && (ledgerRefresh.partial || (hasExcludedProjects && loaded.partial));
+      const summaryPartial = loaded.scanPartial || (hasExcludedProjects && loaded.sourceListPartial);
+      const partialHistoryScan = ledgerRefresh.partial || summaryPartial;
       const nextSummaries = partialHistoryScan && initialRefreshDone
         ? new Map([...this.summaries, ...loaded.summaries])
         : loaded.summaries;
@@ -2110,6 +2116,8 @@ export class StateManager {
           ledgerScannedFiles: ledgerRefresh.scannedFiles,
           partial: partialHistoryScan,
           summaryPartial: loaded.partial,
+          summarySourcePartial: loaded.sourceListPartial,
+          summaryScanPartial: loaded.scanPartial,
           ledgerPartial: ledgerRefresh.partial,
           scanBudgetMs: effectiveScanBudgetMs,
           ...(apiPerf ? this.perfFields('api', apiPerf) : {}),
@@ -2168,6 +2176,8 @@ export class StateManager {
         ledgerScannedFiles: ledgerRefresh.scannedFiles,
         partial: partialHistoryScan,
         summaryPartial: loaded.partial,
+        summarySourcePartial: loaded.sourceListPartial,
+        summaryScanPartial: loaded.scanPartial,
         ledgerPartial: ledgerRefresh.partial,
         scanBudgetMs: effectiveScanBudgetMs,
         ...(apiPerf ? this.perfFields('api', apiPerf) : {}),
@@ -2626,6 +2636,8 @@ export class StateManager {
     codexRateLimits: SessionSnapshot['codexRateLimits'] | null;
     scannedFiles: number;
     partial: boolean;
+    sourceListPartial: boolean;
+    scanPartial: boolean;
   }> {
     const settings = this.getSettings();
     const isExcluded = makeExcludedMatcher(settings.excludedProjects ?? []);
@@ -2634,7 +2646,8 @@ export class StateManager {
     let sessionCount = 0;
     let codexRateLimits: SessionSnapshot['codexRateLimits'] | null = null;
     let scannedFiles = 0;
-    let partial = false;
+    let sourceListPartial = false;
+    let scanPartial = false;
     const startedAt = Date.now();
     const startupPriority = new Set<string>();
     for (const filePath of priorityFiles ?? []) startupPriority.add(normalizeFileKey(filePath));
@@ -2693,7 +2706,7 @@ export class StateManager {
           const cachedLoose = allowPersistedReuse ? this.jsonlCache.get(source.filePath) : null;
           if (cachedLoose && cachedLoose.mtimeMs === stat.mtimeMs && cachedLoose.size === stat.size) return cachedLoose;
           if (!priority && shouldStopForBudget()) {
-            partial = true;
+            scanPartial = true;
             return null;
           }
         }
@@ -2705,7 +2718,7 @@ export class StateManager {
         }
 
         if (!priority && shouldStopForBudget()) {
-          partial = true;
+          scanPartial = true;
           const fallback = this.summaries.get(normalizedPath) ?? this.jsonlCache.getFresh(source.filePath, stat.mtimeMs, stat.size);
           return fallback;
         }
@@ -2728,7 +2741,7 @@ export class StateManager {
       const sourceList = includeFullHistory
         ? provider.listAllSources(ctx)
         : provider.listRecentSources(ctx, this.startupLimitForProvider(provider.id));
-      partial = partial || sourceList.truncated;
+      sourceListPartial = sourceListPartial || sourceList.truncated;
       for (const source of sourceList.sources) {
         const key = normalizeFileKey(source.filePath);
         if (!sourcesByPath.has(key)) sourcesByPath.set(key, source);
@@ -2740,7 +2753,7 @@ export class StateManager {
       for (const source of sources) {
         const priority = shouldPrioritize(source);
         if (!priority && shouldStopForBudget()) {
-          partial = true;
+          scanPartial = true;
           break;
         }
         if (provider.isExcludedSource?.(source, isExcluded)) {
@@ -2771,7 +2784,7 @@ export class StateManager {
     const elapsedMs = Date.now() - startedAt;
     const remainingBudgetMs = budgetMs === null ? null : Math.max(0, budgetMs - elapsedMs);
     if (remainingBudgetMs === 0) {
-      partial = true;
+      scanPartial = true;
     } else {
       const genericCtx = budgetMs === null
         ? ctx
@@ -2787,11 +2800,20 @@ export class StateManager {
         summaries.set(key, summary);
       }
       scannedFiles += genericUsage.scannedFiles;
-      partial = partial || genericUsage.partial;
+      scanPartial = scanPartial || genericUsage.partial;
       ledgerSources = genericUsage.ledgerSources;
     }
 
-    return { summaries, ledgerSources, sessionCount, codexRateLimits, scannedFiles, partial };
+    return {
+      summaries,
+      ledgerSources,
+      sessionCount,
+      codexRateLimits,
+      scannedFiles,
+      partial: sourceListPartial || scanPartial,
+      sourceListPartial,
+      scanPartial,
+    };
   }
 
   private async refreshChangedSummaries(changedFiles: Set<string>): Promise<void> {
@@ -3118,6 +3140,7 @@ export class StateManager {
   applySettingsChange() {
     const settings = this.getSettings();
     const providerChanged = this.providerSelectionChanged(settings, this.state.settings);
+    const quotaSettingsChanged = this.quotaAffectingSettingsChanged(settings, this.state.settings);
     if (providerChanged) {
       this.summaries.clear();
       clearSessionMetadataCache();
@@ -3180,6 +3203,14 @@ export class StateManager {
       lastUpdated: Date.now(),
     };
     this.publishState();
+    if (quotaSettingsChanged && this.enabledProviderSet(settings).has('antigravity')) {
+      void this.requestRefresh({
+        mode: 'heavy',
+        reason: 'settings',
+        force: true,
+        scanBudgetMs: StateManager.FOREGROUND_SCAN_BUDGET_MS,
+      });
+    }
   }
 
   private async logMemorySnapshot(label: string, scannedFiles = 0): Promise<void> {

--- a/src/main/usageLedgerUsage.ts
+++ b/src/main/usageLedgerUsage.ts
@@ -318,9 +318,13 @@ export function computeUsageFromLedger(
   const addProviderWindowAggregate = (row: KeyedAggregate, aggregate: UsageAggregate): void => {
     if (!isProviderId(row.provider)) return;
     const usage = getProviderWindowUsage(row.provider);
+    const addedWindowKeys = new Set<string>();
     for (const target of providerWindowTargets.get(row.provider) ?? []) {
       if (row.timestampMs < target.startMs) continue;
       if (!targetAcceptsModel(target, row.model)) continue;
+      const windowModelKey = `${target.windowKey}\0${row.model}`;
+      if (addedWindowKeys.has(windowModelKey)) continue;
+      addedWindowKeys.add(windowModelKey);
       usage.windows[target.windowKey] ??= emptyWindow();
       addAggregate(usage.windows[target.windowKey], aggregate);
       addAggregate(getProviderModelWindow(row.provider, target.windowKey, row.model), aggregate);

--- a/src/main/usageWindowTargets.ts
+++ b/src/main/usageWindowTargets.ts
@@ -34,7 +34,18 @@ function modelQuotaDuration(model: NonNullable<ProviderQuotaSnapshot['models']>[
 }
 
 function modelQuotaWindowKey(model: NonNullable<ProviderQuotaSnapshot['models']>[number]): string {
+  const durationMs = modelQuotaDuration(model);
+  if (durationMs === H5_MS) return 'h5';
+  if (durationMs === WEEK_MS) return 'week';
   return model.statsWindowKey || `model.${model.model}`;
+}
+
+function modelQuotaIncludes(model: NonNullable<ProviderQuotaSnapshot['models']>[number]): string[] | undefined {
+  const normalized = [model.usageModel, model.label, model.model]
+    .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    .map(item => item.trim().toLowerCase());
+  const unique = [...new Set(normalized)];
+  return unique.length > 0 ? unique : undefined;
 }
 
 function quotaWindowStart(
@@ -119,6 +130,7 @@ export function buildProviderWindowTargets(
         provider,
         modelQuotaWindowKey(model),
         rollingWindowStart(durationMs, model.resetMs, nowMs - durationMs, nowMs),
+        modelQuotaIncludes(model),
       );
     }
 

--- a/src/main/usageWindows.ts
+++ b/src/main/usageWindows.ts
@@ -287,9 +287,13 @@ export function computeUsage(
   const addProviderWindowEntry = (entry: CompactRecentEntry, timestampMs: number) => {
     if (!isProviderId(entry.provider)) return;
     const usage = getProviderWindowUsage(entry.provider);
+    const addedWindowKeys = new Set<string>();
     for (const target of providerWindowTargets.get(entry.provider) ?? []) {
       if (timestampMs < target.startMs) continue;
       if (!targetAcceptsModel(target, entry.model)) continue;
+      const windowModelKey = `${target.windowKey}\0${entry.model}`;
+      if (addedWindowKeys.has(windowModelKey)) continue;
+      addedWindowKeys.add(windowModelKey);
       usage.windows[target.windowKey] ??= emptyWindow();
       addEntry(usage.windows[target.windowKey], entry);
       addEntry(getProviderModelWindow(entry.provider, target.windowKey, entry.model), entry);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -74,6 +74,7 @@ const DEFAULT_STATE: AppState = {
     hiddenProjects: [], excludedProjects: [],
     quotaTargetModes: {},
     quotaTargetOrder: [],
+    antigravityQuotaDurationPaceEnabled: false,
     compactWidgetEnabled: false, compactWidgetWaitingAnimationEnabled: false, compactWidgetBounds: null,
   },
   codexAccount: { serviceTier: null },
@@ -331,6 +332,7 @@ function normalizeProviderQuotaSnapshot(provider: ProviderId, value: unknown): P
     source: isQuotaSource(record.source) ? record.source : 'cache',
     capturedAt: typeof record.capturedAt === 'number' && Number.isFinite(record.capturedAt) ? record.capturedAt : 0,
     accountLabel: typeof record.accountLabel === 'string' ? record.accountLabel : undefined,
+    accountTooltip: typeof record.accountTooltip === 'string' ? record.accountTooltip : undefined,
     planName: typeof record.planName === 'string' ? record.planName : undefined,
     windows: Object.keys(windows).length > 0 ? windows : undefined,
     models: models && models.length > 0 ? models : undefined,
@@ -527,6 +529,7 @@ function normalizeState(next: AppState): AppState {
       excludedProjects: arrayOrEmpty(next.settings?.excludedProjects),
       quotaTargetModes: normalizeQuotaTargetModes(next.settings?.quotaTargetModes),
       quotaTargetOrder: normalizeQuotaTargetOrder(next.settings?.quotaTargetOrder),
+      antigravityQuotaDurationPaceEnabled: next.settings?.antigravityQuotaDurationPaceEnabled === true,
       compactWidgetEnabled: next.settings?.compactWidgetEnabled === true,
       compactWidgetWaitingAnimationEnabled: next.settings?.compactWidgetWaitingAnimationEnabled === true,
       compactWidgetBounds: next.settings?.compactWidgetBounds

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -332,7 +332,7 @@ function normalizeProviderQuotaSnapshot(provider: ProviderId, value: unknown): P
     source: isQuotaSource(record.source) ? record.source : 'cache',
     capturedAt: typeof record.capturedAt === 'number' && Number.isFinite(record.capturedAt) ? record.capturedAt : 0,
     accountLabel: typeof record.accountLabel === 'string' ? record.accountLabel : undefined,
-    accountTooltip: typeof record.accountTooltip === 'string' ? record.accountTooltip : undefined,
+    accountTooltip: typeof record.accountLabel === 'string' ? record.accountLabel : undefined,
     planName: typeof record.planName === 'string' ? record.planName : undefined,
     windows: Object.keys(windows).length > 0 ? windows : undefined,
     models: models && models.length > 0 ? models : undefined,

--- a/src/renderer/components/TokenStatsCard.tsx
+++ b/src/renderer/components/TokenStatsCard.tsx
@@ -24,11 +24,6 @@ function formatUsagePct(pct: number): string {
   return `${Math.round(pct)}%`;
 }
 
-function truncateTitle(title: string, maxChars = 15): string {
-  const chars = Array.from(title);
-  return chars.length > maxChars ? chars.slice(0, maxChars).join('') : title;
-}
-
 function timeElapsedPct(durationMs: number | null | undefined, resetMs: number | null | undefined): number | null {
   if (!durationMs || resetMs == null || resetMs < 0 || resetMs > durationMs) return null;
   return Math.max(0, Math.min(100, ((durationMs - resetMs) / durationMs) * 100));
@@ -228,7 +223,6 @@ function TokenStatsCard({
   const showSavings = stats.cacheSavingsUSD > 0.005;
   const breakdownTokens = stats.inputTokens + stats.outputTokens + stats.cacheCreationTokens + stats.cacheReadTokens;
   const displayTitle = `${provider} ${period}`;
-  const visibleTitle = truncateTitle(displayTitle);
   const displayTitleTooltip = accountTooltip ? `${displayTitle} · ${accountTooltip}` : displayTitle;
   const displayLimitSourceLabel = pendingLimit ? (pendingLimitLabel ?? 'Syncing') : limitSourceLabel;
   const displayLimitSourceTitle = pendingLimitTitle ?? limitSourceTitle ?? displayLimitSourceLabel ?? '';
@@ -265,7 +259,7 @@ function TokenStatsCard({
       }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 6, marginBottom: 2 }}>
           <span title={displayTitleTooltip} style={{ fontSize: 10, fontWeight: 700, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 1, minWidth: 0, flex: '1 1 auto', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {visibleTitle}
+            {displayTitle}
             {!displayLimitSourceLabel && apiConnected === false && limitPct != null && limitPct > 0 && (
               <span style={{ opacity: 0.6, fontWeight: 400, marginLeft: 4 }}>(cached)</span>
             )}

--- a/src/renderer/components/TokenStatsCard.tsx
+++ b/src/renderer/components/TokenStatsCard.tsx
@@ -24,6 +24,11 @@ function formatUsagePct(pct: number): string {
   return `${Math.round(pct)}%`;
 }
 
+function truncateTitle(title: string, maxChars = 15): string {
+  const chars = Array.from(title);
+  return chars.length > maxChars ? chars.slice(0, maxChars).join('') : title;
+}
+
 function timeElapsedPct(durationMs: number | null | undefined, resetMs: number | null | undefined): number | null {
   if (!durationMs || resetMs == null || resetMs < 0 || resetMs > durationMs) return null;
   return Math.max(0, Math.min(100, ((durationMs - resetMs) / durationMs) * 100));
@@ -51,6 +56,7 @@ interface Props {
   pendingLimitTitle?: string;
   cacheMetricTitle?: string;
   durationMs?: number;
+  accountTooltip?: string;
 }
 
 function TokenDotRow({ label, value, color }: { label: string; value: number; color: string }) {
@@ -186,6 +192,7 @@ function TokenStatsCard({
   pendingLimitTitle,
   cacheMetricTitle,
   durationMs,
+  accountTooltip,
 }: Props) {
   const C = useTheme();
 
@@ -221,6 +228,8 @@ function TokenStatsCard({
   const showSavings = stats.cacheSavingsUSD > 0.005;
   const breakdownTokens = stats.inputTokens + stats.outputTokens + stats.cacheCreationTokens + stats.cacheReadTokens;
   const displayTitle = `${provider} ${period}`;
+  const visibleTitle = truncateTitle(displayTitle);
+  const displayTitleTooltip = accountTooltip ? `${displayTitle} · ${accountTooltip}` : displayTitle;
   const displayLimitSourceLabel = pendingLimit ? (pendingLimitLabel ?? 'Syncing') : limitSourceLabel;
   const displayLimitSourceTitle = pendingLimitTitle ?? limitSourceTitle ?? displayLimitSourceLabel ?? '';
   const cachedDisconnected = apiConnected === false && limitSourceLabel === 'Cache';
@@ -255,8 +264,8 @@ function TokenStatsCard({
         background: C.bgCard,
       }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-          <span title={displayTitle} style={{ fontSize: 10, fontWeight: 700, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 1, minWidth: 0, flex: '1 1 auto', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {displayTitle}
+          <span title={displayTitleTooltip} style={{ fontSize: 10, fontWeight: 700, color: C.textMuted, textTransform: 'uppercase', letterSpacing: 1, minWidth: 0, flex: '1 1 auto', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {visibleTitle}
             {!displayLimitSourceLabel && apiConnected === false && limitPct != null && limitPct > 0 && (
               <span style={{ opacity: 0.6, fontWeight: 400, marginLeft: 4 }}>(cached)</span>
             )}

--- a/src/renderer/quotaDisplayModels.ts
+++ b/src/renderer/quotaDisplayModels.ts
@@ -244,12 +244,22 @@ function addStats(target: WindowStats, stats: WindowStats): void {
     : 0;
 }
 
-function fallbackModelStatsWindowKey(model: ProviderModelQuota): string | null {
-  if (model.statsWindowKey) return model.statsWindowKey;
-  if (model.durationMs === FIVE_HOURS_MS) return 'h5';
-  if (model.durationMs === WEEK_MS) return 'week';
-  if (model.resetMs != null) return model.resetMs <= FIVE_HOURS_MS ? 'h5' : 'week';
-  return null;
+function fallbackModelStatsWindowKeys(model: ProviderModelQuota): string[] {
+  const keys: string[] = [];
+  if (model.statsWindowKey) keys.push(model.statsWindowKey);
+  if (model.durationMs === FIVE_HOURS_MS) keys.push('h5');
+  else if (model.durationMs === WEEK_MS) keys.push('week');
+  else if (model.resetMs != null) keys.push(model.resetMs <= FIVE_HOURS_MS ? 'h5' : 'week');
+  return [...new Set(keys)];
+}
+
+function hasStatsSignal(stats: WindowStats): boolean {
+  return stats.totalTokens > 0
+    || stats.requestCount > 0
+    || stats.inputTokens > 0
+    || stats.outputTokens > 0
+    || stats.cacheCreationTokens > 0
+    || stats.cacheReadTokens > 0;
 }
 
 function modelStats(
@@ -257,20 +267,21 @@ function modelStats(
   provider: ProviderId,
   model: ProviderModelQuota,
 ): WindowStats {
-  const windowKey = fallbackModelStatsWindowKey(model);
-  if (!windowKey) return EMPTY_WINDOW_STATS;
-  const windowModels = usage.modelWindows?.[provider]?.windows?.[windowKey];
-  if (!windowModels) return EMPTY_WINDOW_STATS;
   const candidateNames = new Set(
     [model.usageModel, model.label, model.model]
       .filter((value): value is string => typeof value === 'string' && value.length > 0),
   );
-  const stats = { ...EMPTY_WINDOW_STATS };
-  for (const candidate of candidateNames) {
-    const candidateStats = windowModels[candidate];
-    if (candidateStats) addStats(stats, candidateStats);
+  for (const windowKey of fallbackModelStatsWindowKeys(model)) {
+    const windowModels = usage.modelWindows?.[provider]?.windows?.[windowKey];
+    if (!windowModels) continue;
+    const stats = { ...EMPTY_WINDOW_STATS };
+    for (const candidate of candidateNames) {
+      const candidateStats = windowModels[candidate];
+      if (candidateStats) addStats(stats, candidateStats);
+    }
+    if (hasStatsSignal(stats)) return stats;
   }
-  return stats;
+  return EMPTY_WINDOW_STATS;
 }
 
 function buildGroupRows(

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -237,6 +237,7 @@ export interface ProviderQuotaSnapshot {
   source: ProviderQuotaSource;
   capturedAt: number;
   accountLabel?: string;
+  accountTooltip?: string;
   planName?: string;
   windows?: Record<string, ProviderQuotaWindow>;
   models?: ProviderModelQuota[];
@@ -262,6 +263,7 @@ export interface AppSettings {
   excludedProjects: string[];
   quotaTargetModes: Partial<Record<string, QuotaDisplayMode>>;
   quotaTargetOrder: string[];
+  antigravityQuotaDurationPaceEnabled: boolean;
   compactWidgetEnabled: boolean;
   compactWidgetWaitingAnimationEnabled: boolean;
   compactWidgetBounds: { x: number; y: number } | null;

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -809,6 +809,7 @@ function SimpleQuotaRow({ row }: { row: QuotaDisplayRowViewModel }) {
 
 function SimpleQuotaGroupBlock({ group }: { group: QuotaDisplayGroupViewModel }) {
   const C = useTheme();
+  const totalTokens = group.rows.reduce((max, row) => Math.max(max, row.stats.totalTokens), 0);
   return (
     <div style={{ padding: '6px 12px', borderTop: `1px solid ${C.border}` }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2, minWidth: 0 }}>
@@ -827,7 +828,7 @@ function SimpleQuotaGroupBlock({ group }: { group: QuotaDisplayGroupViewModel })
         >
           {group.label}
         </span>
-        {group.badges.length > 0 && (
+        {(group.badges.length > 0 || totalTokens > 0) && (
           <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 4, minWidth: 0, overflow: 'hidden' }}>
             {group.badges.map(badge => (
               <span
@@ -846,6 +847,24 @@ function SimpleQuotaGroupBlock({ group }: { group: QuotaDisplayGroupViewModel })
                 {badge.label}
               </span>
             ))}
+            {totalTokens > 0 && (
+              <span
+                title="Total tokens for this quota target"
+                style={{
+                  background: C.bgRow,
+                  color: C.textDim,
+                  border: `1px solid ${C.border}`,
+                  borderRadius: 3,
+                  padding: '1px 4px',
+                  fontSize: 9,
+                  fontWeight: 700,
+                  fontFamily: C.fontMono,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {fmtTokens(totalTokens)} tok
+              </span>
+            )}
           </span>
         )}
       </div>
@@ -893,6 +912,7 @@ const PlanUsagePanel = React.memo(function PlanUsagePanel({
           {richRow.cards.map((cardView, cardIndex) => {
             const { group, row: card } = cardView;
             const source = limitSourceDisplay(card.quota);
+            const accountTooltip = providerQuotas[cardView.provider]?.accountTooltip;
             return (
               <TokenStatsCard
                 key={cardView.key}
@@ -914,6 +934,7 @@ const PlanUsagePanel = React.memo(function PlanUsagePanel({
                 pendingLimitTitle={card.pendingTitle}
                 cacheMetricTitle={card.cacheMetricTitle}
                 durationMs={card.durationMs}
+                accountTooltip={accountTooltip}
                 hideCost={card.hideCost}
                 hero
                 borderRight={richRow.cards.length > 1 && cardIndex === 0}

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -809,7 +809,17 @@ function SimpleQuotaRow({ row }: { row: QuotaDisplayRowViewModel }) {
 
 function SimpleQuotaGroupBlock({ group }: { group: QuotaDisplayGroupViewModel }) {
   const C = useTheme();
-  const totalTokens = group.rows.reduce((max, row) => Math.max(max, row.stats.totalTokens), 0);
+  const tokenRows = group.rows.filter(row => row.stats.totalTokens > 0);
+  const tokenBadge = tokenRows.length === 0
+    ? null
+    : {
+      value: tokenRows.length === 1
+        ? tokenRows[0].stats.totalTokens
+        : tokenRows.reduce((max, row) => Math.max(max, row.stats.totalTokens), 0),
+      title: tokenRows.length === 1
+        ? 'Total tokens for this quota target'
+        : 'Largest window token count for this quota target',
+    };
   return (
     <div style={{ padding: '6px 12px', borderTop: `1px solid ${C.border}` }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2, minWidth: 0 }}>
@@ -828,7 +838,7 @@ function SimpleQuotaGroupBlock({ group }: { group: QuotaDisplayGroupViewModel })
         >
           {group.label}
         </span>
-        {(group.badges.length > 0 || totalTokens > 0) && (
+        {(group.badges.length > 0 || tokenBadge) && (
           <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 4, minWidth: 0, overflow: 'hidden' }}>
             {group.badges.map(badge => (
               <span
@@ -847,9 +857,9 @@ function SimpleQuotaGroupBlock({ group }: { group: QuotaDisplayGroupViewModel })
                 {badge.label}
               </span>
             ))}
-            {totalTokens > 0 && (
+            {tokenBadge && (
               <span
-                title="Total tokens for this quota target"
+                title={tokenBadge.title}
                 style={{
                   background: C.bgRow,
                   color: C.textDim,
@@ -862,7 +872,7 @@ function SimpleQuotaGroupBlock({ group }: { group: QuotaDisplayGroupViewModel })
                   whiteSpace: 'nowrap',
                 }}
               >
-                {fmtTokens(totalTokens)} tok
+                {fmtTokens(tokenBadge.value)} tok
               </span>
             )}
           </span>

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -491,9 +491,9 @@ export default function SettingsView({ settings, providerQuotas, onSave, onBack 
         {enabledProvidersFromSettings(s).includes('antigravity') && (
           <div style={row}>
             <div>
-              <div style={labelStyle}>Antigravity quota pace</div>
+              <div style={labelStyle}>Antigravity quota pace estimate</div>
               <div style={{ fontSize: 10, color: C.textMuted, marginTop: 2 }}>
-                Infer 5h or weekly pacing from reset times; off keeps Antigravity model quotas percent-only
+                Estimate 5h or weekly pacing from reset times; off keeps Antigravity model quotas percent-only
               </div>
             </div>
             <input

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -97,6 +97,7 @@ const EDITABLE_SETTING_KEYS: EditableSettingKey[] = [
   'excludedProjects',
   'quotaTargetModes',
   'quotaTargetOrder',
+  'antigravityQuotaDurationPaceEnabled',
   'compactWidgetEnabled',
   'compactWidgetWaitingAnimationEnabled',
   'theme',
@@ -108,6 +109,7 @@ function normalizeSettingsDraft(settings: AppSettings): AppSettings {
     ...settings,
     quotaTargetModes: settings.quotaTargetModes ?? {},
     quotaTargetOrder: settings.quotaTargetOrder ?? [],
+    antigravityQuotaDurationPaceEnabled: settings.antigravityQuotaDurationPaceEnabled === true,
     mainSectionOrder,
     hiddenMainSections: normalizeHiddenMainSections(settings.hiddenMainSections, mainSectionOrder),
   };
@@ -486,6 +488,22 @@ export default function SettingsView({ settings, providerQuotas, onSave, onBack 
             })}
           </div>
         </div>
+        {enabledProvidersFromSettings(s).includes('antigravity') && (
+          <div style={row}>
+            <div>
+              <div style={labelStyle}>Antigravity quota pace</div>
+              <div style={{ fontSize: 10, color: C.textMuted, marginTop: 2 }}>
+                Infer 5h or weekly pacing from reset times; off keeps Antigravity model quotas percent-only
+              </div>
+            </div>
+            <input
+              type="checkbox"
+              style={chk}
+              checked={s.antigravityQuotaDurationPaceEnabled}
+              onChange={e => setS({ ...s, antigravityQuotaDurationPaceEnabled: e.target.checked })}
+            />
+          </div>
+        )}
         {quotaTargetOptions.length > 0 && (
           <div style={{ padding: '8px 0', borderBottom: `1px solid ${C.border}` }}>
             <div style={{ ...labelStyle, marginBottom: 6 }}>Quota display</div>


### PR DESCRIPTION
﻿## Summary

This PR focuses on quota correctness and refresh stability.

- Fixes an infinite startup history warmup loop where normal recent-summary truncation could keep the UI in `Partial History / syncing` forever.
- Stabilizes Antigravity quota server selection by preferring the local language server with the newest cascade activity.
- Prevents elapsed Antigravity reset windows from being treated as active quota duration windows.
- Keeps Antigravity model token statistics visible when quota pace mode is toggled.
- Adds optional Antigravity quota pace display, disabled by default, so model quota cards stay percent-only unless explicitly enabled.
- Infers Antigravity 5h / weekly pacing duration from quota reset timing only when the setting is enabled.
- Masks the Antigravity account label in the UI while exposing the full account email only through quota-card tooltip metadata.
- Improves quota display readability with 15-character rich-card title truncation and total-token labels in simple quota mode.

## Why

The main issue was stability and accuracy rather than feature coverage.

- Startup could repeatedly schedule history warmup every 3 seconds even after full history had already been imported.
- Antigravity quota values could come from the wrong local server when multiple Antigravity language servers were running.
- Reset timing edge cases could make quota pacing misleading.
- Token usage display could disappear or appear inconsistent after quota pace settings changed.

## Behavior changes

- `Partial History` now only stays active for real incomplete history scans, not normal recent-summary truncation.
- Antigravity quota selection is biased toward the server with the freshest cascade activity.
- Antigravity quota pace remains opt-in and defaults off.
- When pace is off, Antigravity model quota cards remain percent-only.
- Simple quota mode now shows total token usage next to the source badge.

## Verification

- Ran `node --test scripts/antigravity-provider-integration.test.mjs`.
- Ran `npm.cmd run dist`.
- Confirmed Windows installer, portable exe, and unpacked app artifacts were produced under `release/`.
