### PR TITLE
fix: widen CALIB_MAX to 5.0 for short thinking block outliers

### DIFF
--- a/scripts/output-splitter.test.mjs
+++ b/scripts/output-splitter.test.mjs
@@ -90,8 +90,9 @@ test('no char signal: non-thinking remainder goes entirely to response (determin
 });
 
 test('CALIB drift guard: observed-band ratios pass, scheme-change ratio throws', () => {
-  assertCalibInBand(150, 100); // 1.5 — spec observed min, in band
-  assertCalibInBand(265, 100); // 2.65 — spec observed max, in band
+  assertCalibInBand(150, 100); // 1.5 — well within band
+  assertCalibInBand(265, 100); // 2.65 — near CALIB center
+  assertCalibInBand(379, 100); // 3.79 — short-block real-world outlier, within CALIB_MAX=5.0
   assert.throws(() => assertCalibInBand(1000, 100)); // 10x — out of band
   assert.throws(() => assertCalibInBand(110, 100));  // 1.1 — below CALIB_MIN
 });

--- a/scripts/output-splitter.test.mjs
+++ b/scripts/output-splitter.test.mjs
@@ -90,11 +90,11 @@ test('no char signal: non-thinking remainder goes entirely to response (determin
 });
 
 test('CALIB drift guard: observed-band ratios pass, scheme-change ratio throws', () => {
-  assertCalibInBand(150, 100); // 1.5 — well within band
-  assertCalibInBand(265, 100); // 2.65 — near CALIB center
-  assertCalibInBand(379, 100); // 3.79 — short-block real-world outlier, within CALIB_MAX=5.0
-  assert.throws(() => assertCalibInBand(1000, 100)); // 10x — out of band
-  assert.throws(() => assertCalibInBand(110, 100));  // 1.1 — below CALIB_MIN
+  assertCalibInBand(150, 100); // 1.5는 허용 범위 안이다.
+  assertCalibInBand(265, 100); // 2.65는 CALIB 중심값에 가깝다.
+  assertCalibInBand(379, 100); // 3.79는 짧은 블록에서 관측된 실제 outlier다.
+  assert.throws(() => assertCalibInBand(1000, 100)); // 10x는 허용 범위 밖이다.
+  assert.throws(() => assertCalibInBand(110, 100));  // 1.1은 CALIB_MIN 아래다.
 });
 
 test('compositionToDelta flattens nested toolOutput to flat row keys', () => {

--- a/src/main/outputSplitter.ts
+++ b/src/main/outputSplitter.ts
@@ -6,7 +6,7 @@ import {
 
 export const CALIB = 2.4;
 export const CALIB_MIN = 1.2;
-export const CALIB_MAX = 3.4;
+export const CALIB_MAX = 5.0; // widened from 3.4: short thinking blocks have naturally higher sig/text ratios due to fixed signature overhead
 
 export function signatureProxyThinkingChars(signatureLength: number): number {
   return signatureLength > 0 ? signatureLength / CALIB : 0;

--- a/src/main/outputSplitter.ts
+++ b/src/main/outputSplitter.ts
@@ -6,7 +6,7 @@ import {
 
 export const CALIB = 2.4;
 export const CALIB_MIN = 1.2;
-export const CALIB_MAX = 5.0; // widened from 3.4: short thinking blocks have naturally higher sig/text ratios due to fixed signature overhead
+export const CALIB_MAX = 5.0; // 짧은 thinking 블록은 고정 signature 오버헤드 때문에 sig/text 비율이 더 높을 수 있다.
 
 export function signatureProxyThinkingChars(signatureLength: number): number {
   return signatureLength > 0 ? signatureLength / CALIB : 0;


### PR DESCRIPTION
## Summary

- `CALIB_MAX` was set to `3.4`, but real Claude responses can have a sig/text ratio of ~3.79 when thinking blocks are short — the signature has fixed-size overhead that makes the ratio naturally higher for brief thinking
- Before v1.19.0: this caused an uncaught exception in the ReadStream handler, crashing the entire app
- After v1.19.0 (`1cdbd8a`): the crash was caught and converted to `importFailed = true`, disabling the usage ledger feature entirely — but the root cause was not fixed
- This PR widens `CALIB_MAX` to `5.0`, which accommodates short-block outliers while still catching true encoding drift (which would appear as 10x+ shifts)

## Test Plan

- [x] All 465 existing tests pass
- [x] Added test case `assertCalibInBand(379, 100)` (ratio 3.79) to the CALIB drift guard test to document the real-world outlier that triggered this fix