### PR TITLE
fix: throttle trend breakdown refreshes

### DIFF
--- a/scripts/trend-section.test.mjs
+++ b/scripts/trend-section.test.mjs
@@ -120,6 +120,33 @@ test('TrendCard wires click selection to the inline breakdown card', () => {
   assert.match(trendCard, /handleChartKeyDown/);
 });
 
+test('TrendCard breakdown effect uses stable selected bucket inputs', () => {
+  const trendCard = fs.readFileSync('src/renderer/components/TrendCard.tsx', 'utf8');
+  assert.match(trendCard, /const selectedExists = selectedKey !== null && selectedIndex >= 0/);
+  assert.match(trendCard, /}, \[selectedKey, selectedSignature, grain, selectedExists\]\)/);
+  assert.doesNotMatch(trendCard, /}, \[[^\]]*selectedRow[^\]]*\]\)/);
+});
+
+test('TrendCard clears stale breakdown only when the selected bucket identity changes', () => {
+  const trendCard = fs.readFileSync('src/renderer/components/TrendCard.tsx', 'utf8');
+  assert.match(trendCard, /useRef<string \| null>\(null\)/);
+  assert.match(trendCard, /breakdownRequestKeyRef\.current = null/);
+  assert.match(trendCard, /const requestKey = `\$\{grain\}\|\$\{selectedKey\}`/);
+  assert.match(trendCard, /const isNewRequestKey = breakdownRequestKeyRef\.current !== requestKey/);
+  assert.match(trendCard, /if \(isNewRequestKey\) \{\s*setBreakdown\(null\);\s*\}/);
+  assert.match(trendCard, /breakdownRequestKeyRef\.current = requestKey/);
+});
+
+test('TrendCard throttles same-bucket breakdown refreshes without showing loading', () => {
+  const trendCard = fs.readFileSync('src/renderer/components/TrendCard.tsx', 'utf8');
+  assert.match(trendCard, /const BREAKDOWN_REFRESH_THROTTLE_MS = 30_000/);
+  assert.match(trendCard, /const breakdownRefreshDueAtRef = useRef\(0\)/);
+  assert.match(trendCard, /const isNewRequestKey = breakdownRequestKeyRef\.current !== requestKey/);
+  assert.match(trendCard, /if \(!isNewRequestKey && now < breakdownRefreshDueAtRef\.current\) return/);
+  assert.match(trendCard, /breakdownRefreshDueAtRef\.current = now \+ BREAKDOWN_REFRESH_THROTTLE_MS/);
+  assert.match(trendCard, /setLoading\(isNewRequestKey\)/);
+});
+
 test('TrendCard does not draw missing usage or output buckets as zero-value trend lines', () => {
   const trendCard = fs.readFileSync('src/renderer/components/TrendCard.tsx', 'utf8');
   assert.match(trendCard, /const primaryValues = rows\.filter\(row => row\.hasUsage\)\.map/);

--- a/scripts/trend-section.test.mjs
+++ b/scripts/trend-section.test.mjs
@@ -123,7 +123,7 @@ test('TrendCard wires click selection to the inline breakdown card', () => {
 test('TrendCard breakdown effect uses stable selected bucket inputs', () => {
   const trendCard = fs.readFileSync('src/renderer/components/TrendCard.tsx', 'utf8');
   assert.match(trendCard, /const selectedExists = selectedKey !== null && selectedIndex >= 0/);
-  assert.match(trendCard, /}, \[selectedKey, selectedSignature, grain, selectedExists\]\)/);
+  assert.match(trendCard, /}, \[selectedKey, selectedSignature, grain, selectedExists, lastUpdated\]\)/);
   assert.doesNotMatch(trendCard, /}, \[[^\]]*selectedRow[^\]]*\]\)/);
 });
 
@@ -133,18 +133,30 @@ test('TrendCard clears stale breakdown only when the selected bucket identity ch
   assert.match(trendCard, /breakdownRequestKeyRef\.current = null/);
   assert.match(trendCard, /const requestKey = `\$\{grain\}\|\$\{selectedKey\}`/);
   assert.match(trendCard, /const isNewRequestKey = breakdownRequestKeyRef\.current !== requestKey/);
-  assert.match(trendCard, /if \(isNewRequestKey\) \{\s*setBreakdown\(null\);\s*\}/);
+  assert.match(trendCard, /if \(isNewRequestKey\) \{\s*breakdownRef\.current = null;\s*setBreakdown\(null\);\s*\}/);
   assert.match(trendCard, /breakdownRequestKeyRef\.current = requestKey/);
 });
 
 test('TrendCard throttles same-bucket breakdown refreshes without showing loading', () => {
   const trendCard = fs.readFileSync('src/renderer/components/TrendCard.tsx', 'utf8');
   assert.match(trendCard, /const BREAKDOWN_REFRESH_THROTTLE_MS = 30_000/);
+  assert.match(trendCard, /const breakdownRef = useRef<BucketBreakdown \| null>\(null\)/);
   assert.match(trendCard, /const breakdownRefreshDueAtRef = useRef\(0\)/);
+  assert.match(trendCard, /const breakdownTrailingTimerRef = useRef/);
   assert.match(trendCard, /const isNewRequestKey = breakdownRequestKeyRef\.current !== requestKey/);
-  assert.match(trendCard, /if \(!isNewRequestKey && now < breakdownRefreshDueAtRef\.current\) return/);
-  assert.match(trendCard, /breakdownRefreshDueAtRef\.current = now \+ BREAKDOWN_REFRESH_THROTTLE_MS/);
-  assert.match(trendCard, /setLoading\(isNewRequestKey\)/);
+  assert.match(trendCard, /if \(!isNewRequestKey && now < breakdownRefreshDueAtRef\.current\) \{/);
+  assert.match(trendCard, /breakdownTrailingTimerRef\.current = window\.setTimeout/);
+  assert.match(trendCard, /refreshBreakdown\(requestKey, selectedKey, breakdownRef\.current === null\)/);
+  assert.match(trendCard, /breakdownRefreshDueAtRef\.current = Date\.now\(\) \+ BREAKDOWN_REFRESH_THROTTLE_MS/);
+  assert.match(trendCard, /const showLoading = isNewRequestKey \|\| breakdown === null/);
+});
+
+test('TrendCard receives state freshness so breakdown-only ledger changes can refresh', () => {
+  const mainView = fs.readFileSync('src/renderer/views/MainView.tsx', 'utf8');
+  const trendCard = fs.readFileSync('src/renderer/components/TrendCard.tsx', 'utf8');
+  assert.match(mainView, /<TrendCard[^>]*lastUpdated=\{state\.lastUpdated\}/);
+  assert.match(trendCard, /lastUpdated: number/);
+  assert.match(trendCard, /}, \[selectedKey, selectedSignature, grain, selectedExists, lastUpdated\]\)/);
 });
 
 test('TrendCard does not draw missing usage or output buckets as zero-value trend lines', () => {

--- a/src/renderer/components/TrendCard.tsx
+++ b/src/renderer/components/TrendCard.tsx
@@ -13,6 +13,7 @@ type CacheView = 'work' | 'billing';
 interface Props {
   usageTrend: UsageTrendData;
   codeOutputStats: CodeOutputStats;
+  lastUpdated: number;
   currency: string;
   usdToKrw: number;
 }
@@ -53,7 +54,7 @@ const GRAIN_WINDOWS: Record<Grain, { limit: number; label: string }> = {
   month: { limit: 12, label: '12m' },
 };
 
-function TrendCard({ usageTrend, codeOutputStats, currency, usdToKrw }: Props) {
+function TrendCard({ usageTrend, codeOutputStats, lastUpdated, currency, usdToKrw }: Props) {
   const C = useTheme();
   const [grain, setGrain] = useState<Grain>('day');
   const [metric, setMetric] = useState<Metric>('cost');
@@ -63,8 +64,10 @@ function TrendCard({ usageTrend, codeOutputStats, currency, usdToKrw }: Props) {
   const [breakdown, setBreakdown] = useState<BucketBreakdown | null>(null);
   const [breakdownError, setBreakdownError] = useState<unknown>(null);
   const [loading, setLoading] = useState(false);
+  const breakdownRef = useRef<BucketBreakdown | null>(null);
   const breakdownRequestKeyRef = useRef<string | null>(null);
   const breakdownRefreshDueAtRef = useRef(0);
+  const breakdownTrailingTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const breakdownRequestSeqRef = useRef(0);
 
   const rows = useMemo(
@@ -109,14 +112,49 @@ function TrendCard({ usageTrend, codeOutputStats, currency, usdToKrw }: Props) {
   const outputPaths = hasOutputSeries ? pathsForRows(rows, points, row => row.hasOutput, point => point.outputY) : [];
 
   useEffect(() => {
+    const clearTrailingRefresh = () => {
+      if (breakdownTrailingTimerRef.current !== null) {
+        window.clearTimeout(breakdownTrailingTimerRef.current);
+        breakdownTrailingTimerRef.current = null;
+      }
+    };
+    const refreshBreakdown = (requestKey: string, bucketKey: string, showLoading: boolean) => {
+      clearTrailingRefresh();
+      breakdownRequestKeyRef.current = requestKey;
+      breakdownRefreshDueAtRef.current = Date.now() + BREAKDOWN_REFRESH_THROTTLE_MS;
+      const requestSeq = ++breakdownRequestSeqRef.current;
+      setLoading(showLoading);
+      setBreakdownError(null);
+      window.wmt.getBreakdown(grain, bucketKey)
+        .then(nextBreakdown => {
+          if (breakdownRequestSeqRef.current === requestSeq) {
+            breakdownRef.current = nextBreakdown;
+            setBreakdown(nextBreakdown);
+          }
+        })
+        .catch(err => {
+          // Surface a fail-loud query error (e.g. dirty-state throw) rather than masking it as an empty state.
+          if (breakdownRequestSeqRef.current === requestSeq) {
+            breakdownRef.current = null;
+            setBreakdown(null);
+            setBreakdownError(err);
+          }
+        })
+        .finally(() => {
+          if (breakdownRequestSeqRef.current === requestSeq) setLoading(false);
+        });
+    };
+
     if (selectedKey !== null && !selectedExists) {
       setSelectedKey(null);
       return;
     }
     if (selectedKey === null) {
+      clearTrailingRefresh();
       breakdownRequestKeyRef.current = null;
       breakdownRefreshDueAtRef.current = 0;
       breakdownRequestSeqRef.current += 1;
+      breakdownRef.current = null;
       setBreakdown(null);
       setBreakdownError(null);
       setLoading(false);
@@ -126,28 +164,24 @@ function TrendCard({ usageTrend, codeOutputStats, currency, usdToKrw }: Props) {
     const requestKey = `${grain}|${selectedKey}`;
     const isNewRequestKey = breakdownRequestKeyRef.current !== requestKey;
     const now = Date.now();
-    if (!isNewRequestKey && now < breakdownRefreshDueAtRef.current) return;
+    const showLoading = isNewRequestKey || breakdown === null;
+    if (!isNewRequestKey && now < breakdownRefreshDueAtRef.current) {
+      const delayMs = Math.max(0, breakdownRefreshDueAtRef.current - now);
+      clearTrailingRefresh();
+      breakdownTrailingTimerRef.current = window.setTimeout(() => {
+        breakdownTrailingTimerRef.current = null;
+        refreshBreakdown(requestKey, selectedKey, breakdownRef.current === null);
+      }, delayMs);
+      return clearTrailingRefresh;
+    }
 
-    setLoading(isNewRequestKey);
     if (isNewRequestKey) {
+      breakdownRef.current = null;
       setBreakdown(null);
     }
-    breakdownRequestKeyRef.current = requestKey;
-    breakdownRefreshDueAtRef.current = now + BREAKDOWN_REFRESH_THROTTLE_MS;
-    const requestSeq = ++breakdownRequestSeqRef.current;
-    setBreakdownError(null);
-    window.wmt.getBreakdown(grain, selectedKey)
-      .then(nextBreakdown => {
-        if (breakdownRequestSeqRef.current === requestSeq) setBreakdown(nextBreakdown);
-      })
-      .catch(err => {
-        // Surface a fail-loud query error (e.g. dirty-state throw) rather than masking it as an empty state.
-        if (breakdownRequestSeqRef.current === requestSeq) { setBreakdown(null); setBreakdownError(err); }
-      })
-      .finally(() => {
-        if (breakdownRequestSeqRef.current === requestSeq) setLoading(false);
-      });
-  }, [selectedKey, selectedSignature, grain, selectedExists]);
+    refreshBreakdown(requestKey, selectedKey, showLoading);
+    return clearTrailingRefresh;
+  }, [selectedKey, selectedSignature, grain, selectedExists, lastUpdated]);
 
   function selectHoverIndex(nextIndex: number) {
     setHoverIndex(prev => prev === nextIndex ? prev : nextIndex);

--- a/src/renderer/components/TrendCard.tsx
+++ b/src/renderer/components/TrendCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { BucketBreakdown, CodeOutputStats, GitDailyStats, UsageTrendData, UsageTrendPoint } from '../types';
 import { useTheme } from '../ThemeContext';
 import { fmtCost, fmtTokens } from '../theme';
@@ -46,6 +46,7 @@ const CACHE_VIEW_LABELS: Record<CacheView, string> = {
 };
 const TREND_COST_COLOR = 'gpt4';
 const CHART = { width: 330, height: 126, left: 12, right: 52, top: 12, bottom: 24 };
+const BREAKDOWN_REFRESH_THROTTLE_MS = 30_000;
 const GRAIN_WINDOWS: Record<Grain, { limit: number; label: string }> = {
   day: { limit: 14, label: '14d' },
   week: { limit: 12, label: '12w' },
@@ -62,6 +63,9 @@ function TrendCard({ usageTrend, codeOutputStats, currency, usdToKrw }: Props) {
   const [breakdown, setBreakdown] = useState<BucketBreakdown | null>(null);
   const [breakdownError, setBreakdownError] = useState<unknown>(null);
   const [loading, setLoading] = useState(false);
+  const breakdownRequestKeyRef = useRef<string | null>(null);
+  const breakdownRefreshDueAtRef = useRef(0);
+  const breakdownRequestSeqRef = useRef(0);
 
   const rows = useMemo(
     () => buildTrendRows(usageTrend, codeOutputStats.dailyAll ?? [], grain),
@@ -77,6 +81,7 @@ function TrendCard({ usageTrend, codeOutputStats, currency, usdToKrw }: Props) {
   const activeIndex = Math.max(0, Math.min(rows.length - 1, hoverIndex === null ? rows.length - 1 : hoverIndex));
   const activeRow = rows[activeIndex] ?? rows[rows.length - 1];
   const selectedIndex = selectedKey === null ? -1 : rows.findIndex(row => row.key === selectedKey);
+  const selectedExists = selectedKey !== null && selectedIndex >= 0;
   const selectedRow = selectedIndex >= 0 ? rows[selectedIndex] : null;
   const selectedSignature = selectedRow
     ? [
@@ -104,37 +109,45 @@ function TrendCard({ usageTrend, codeOutputStats, currency, usdToKrw }: Props) {
   const outputPaths = hasOutputSeries ? pathsForRows(rows, points, row => row.hasOutput, point => point.outputY) : [];
 
   useEffect(() => {
-    if (selectedKey !== null && selectedRow === null) {
+    if (selectedKey !== null && !selectedExists) {
       setSelectedKey(null);
       return;
     }
-    if (selectedKey === null || selectedRow === null) {
+    if (selectedKey === null) {
+      breakdownRequestKeyRef.current = null;
+      breakdownRefreshDueAtRef.current = 0;
+      breakdownRequestSeqRef.current += 1;
       setBreakdown(null);
       setBreakdownError(null);
       setLoading(false);
       return;
     }
 
-    let cancelled = false;
-    setLoading(true);
-    setBreakdown(null);
+    const requestKey = `${grain}|${selectedKey}`;
+    const isNewRequestKey = breakdownRequestKeyRef.current !== requestKey;
+    const now = Date.now();
+    if (!isNewRequestKey && now < breakdownRefreshDueAtRef.current) return;
+
+    setLoading(isNewRequestKey);
+    if (isNewRequestKey) {
+      setBreakdown(null);
+    }
+    breakdownRequestKeyRef.current = requestKey;
+    breakdownRefreshDueAtRef.current = now + BREAKDOWN_REFRESH_THROTTLE_MS;
+    const requestSeq = ++breakdownRequestSeqRef.current;
     setBreakdownError(null);
     window.wmt.getBreakdown(grain, selectedKey)
       .then(nextBreakdown => {
-        if (!cancelled) setBreakdown(nextBreakdown);
+        if (breakdownRequestSeqRef.current === requestSeq) setBreakdown(nextBreakdown);
       })
       .catch(err => {
         // Surface a fail-loud query error (e.g. dirty-state throw) rather than masking it as an empty state.
-        if (!cancelled) { setBreakdown(null); setBreakdownError(err); }
+        if (breakdownRequestSeqRef.current === requestSeq) { setBreakdown(null); setBreakdownError(err); }
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (breakdownRequestSeqRef.current === requestSeq) setLoading(false);
       });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedKey, selectedRow, selectedSignature, grain]);
+  }, [selectedKey, selectedSignature, grain, selectedExists]);
 
   function selectHoverIndex(nextIndex: number) {
     setHoverIndex(prev => prev === nextIndex ? prev : nextIndex);

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -1548,7 +1548,7 @@ export default function MainView({ state, onNav, onQuit, onRefresh, onScrollActi
       case 'trend':
         return (
           <RenderErrorBoundary key={sectionId} label="Trend Card">
-            <TrendCard usageTrend={state.usageTrend} codeOutputStats={state.codeOutputStats} currency={currency} usdToKrw={usdToKrw} />
+            <TrendCard usageTrend={state.usageTrend} codeOutputStats={state.codeOutputStats} lastUpdated={state.lastUpdated} currency={currency} usdToKrw={usdToKrw} />
           </RenderErrorBoundary>
         );
       case 'sessions':


### PR DESCRIPTION
## Summary
- Fix frequent background refreshes causing the expanded Trend usage breakdown to flicker and feel sluggish when today's bucket is selected.
- Throttle same-bucket breakdown refreshes to 30 seconds while keeping the current details visible during live updates.
- Still clear and show loading immediately when the selected bucket identity changes, so switching days/weeks/months remains accurate.

## Root cause
Today's trend bucket changes on fast live refreshes, so the selected bucket signature changed every few seconds. The renderer effect treated each signature change as a full breakdown reload and cleared the details panel before refetching, which caused repeated redraws, visible flicker, and UI stutter while the expanded usage subpage was open.

## Validation
- `rtk node --test scripts/trend-section.test.mjs scripts/trend-breakdown-card.test.mjs`
- `rtk node --test scripts/stability-regressions.test.mjs scripts/refresh-scheduler.test.mjs`
- `rtk npm run build:renderer`
- `rtk npm run build:main`
- `rtk npm test`
- `rtk npm run dist`
