### PR TITLE
fix: refine taskbar mini overflow layout

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -14,7 +14,7 @@ WhereMyTokens is a local-first Windows tray app for AI coding usage observabilit
 - Provider quota cards for Claude, Codex, Antigravity, and future provider adapters.
 - Per-target quota display modes: Rich, Simple, or hidden.
 - Quota Pace compares usage percentage with elapsed reset-window time.
-- Optional draggable Windows taskbar mini quota display with fixed `5h` and `1w` rows, a configurable per-row block limit, hidden-target counts, source/status-colored target prefixes, transparent background, and taskbar-background-aware text contrast.
+- Optional draggable Windows taskbar mini quota display with fixed `5h` and `1w` rows, a configurable per-row block limit, source/status-colored target prefixes, transparent background, and taskbar-background-aware text contrast.
 - Windows toast notifications for configurable usage thresholds.
 - Claude Code `statusLine` bridge support for live local context and fallback quota data.
 

--- a/docs/privacy-security.md
+++ b/docs/privacy-security.md
@@ -17,7 +17,7 @@ WhereMyTokens is local-first. There is no cloud sync and no telemetry.
 | `~/.codex/.codex-global-state.json` | Codex account metadata such as service tier for header labels. Read only when Codex is enabled. | No |
 | Antigravity language server on `127.0.0.1` | Local cascade sessions, model quota percentages, reset times, and token metadata. | Loopback only |
 | `%APPDATA%\WhereMyTokens` | App settings, local caches, ledgers, notification history, bridge state, and auth-bound Codex reset-credit cache. | No |
-| Taskbar mini helper stdin | Optional summarized quota snapshot for fixed `5h` and `1w` rows, hidden-target counts, per-block source/status tone for target-prefix coloring, plus current light/dark display theme fallback. | No |
+| Taskbar mini helper stdin | Optional summarized quota snapshot for fixed `5h` and `1w` rows, visible blocks capped by the configured per-row limit, per-block source/status tone for target-prefix coloring, plus current light/dark display theme fallback. | No |
 | `%LOCALAPPDATA%\WhereMyTokens\TaskbarHelper\layout.json` | Optional taskbar-relative helper position. | No |
 
 ## Credential Handling

--- a/scripts/taskbar-helper-native.test.mjs
+++ b/scripts/taskbar-helper-native.test.mjs
@@ -50,10 +50,14 @@ test('taskbar helper renders a column-aligned grid with full-height separators',
   const minimumMaximumBlockWidth = Number(source.match(/MinimumMaximumBlockWidth\s*=\s*(\d+)/)?.[1]);
   const blockGap = Number(source.match(/BlockGap\s*=\s*(\d+)/)?.[1]);
   const blockHorizontalPadding = Number(source.match(/BlockHorizontalPadding\s*=\s*(\d+)/)?.[1]);
+  const periodWidth = Number(source.match(/PeriodWidth\s*=\s*(\d+)/)?.[1]);
+  const textMeasurePadding = Number(source.match(/TextMeasurePadding\s*=\s*(\d+)/)?.[1]);
   assert.ok(minimumBlockWidth > 0 && minimumBlockWidth <= 120);
   assert.ok(minimumMaximumBlockWidth > 0 && minimumMaximumBlockWidth <= 140);
   assert.ok(blockGap > 0 && blockGap <= 6);
   assert.ok(blockHorizontalPadding > 0 && blockHorizontalPadding <= 2);
+  assert.ok(periodWidth >= 40);
+  assert.ok(textMeasurePadding >= 4);
   assert.match(source, /ClientSize\.Width/);
   assert.match(source, /DividerWidth/);
   assert.match(source, /DrawDivider/);
@@ -64,11 +68,11 @@ test('taskbar helper renders a column-aligned grid with full-height separators',
   assert.doesNotMatch(source, /usableWidth\s*\/\s*2/);
 });
 
-test('taskbar helper renders compact overflow counts for hidden targets', () => {
+test('taskbar helper does not render overflow counts for hidden targets', () => {
   const source = fs.readFileSync(path.resolve('taskbar-helper', 'Program.cs'), 'utf8');
-  assert.match(source, /HiddenCount/);
-  assert.match(source, /DrawOverflowBadge/);
-  assert.match(source, /\$"\+\{hiddenCount\}"/);
+  assert.doesNotMatch(source, /HiddenCount/);
+  assert.doesNotMatch(source, /DrawOverflowBadge/);
+  assert.doesNotMatch(source, /\$"\+\{hiddenCount\}"/);
   assert.doesNotMatch(source, /SourceLabel/);
 });
 
@@ -92,7 +96,6 @@ test('taskbar helper validates semantic snapshot arrays before rendering', () =>
   assert.match(source, /ValidTaskbarPeriods\.Contains\(row\.Period\)/);
   assert.match(source, /row\.Blocks is null/);
   assert.match(source, /row\.Blocks\.Length > 3/);
-  assert.match(source, /row\.HiddenCount < 0/);
   assert.match(source, /string\.IsNullOrWhiteSpace\(block\.TargetId\)/);
   assert.match(source, /ValidQuotaSeverities\.Contains\(block\.Severity\)/);
   assert.match(source, /ValidProviderStatusTones\.Contains\(block\.ProviderStatusTone\)/);
@@ -237,6 +240,9 @@ test('taskbar helper measures owner-drawn text with the same API it uses to draw
   const source = fs.readFileSync(path.resolve('taskbar-helper', 'Program.cs'), 'utf8');
   assert.match(source, /MeasureDrawStringWidth/);
   assert.match(source, /MeasureString/);
+  assert.match(source, /StringFormatFlags\.MeasureTrailingSpaces/);
+  assert.match(source, /StringTrimming\.None/);
+  assert.doesNotMatch(source, /StringTrimming\.EllipsisCharacter/);
   assert.doesNotMatch(source, /private int DrawMeasuredText[\s\S]*?TextRenderer\.MeasureText/);
 });
 

--- a/scripts/taskbar-quota-snapshot.test.mjs
+++ b/scripts/taskbar-quota-snapshot.test.mjs
@@ -91,7 +91,7 @@ test('builds exactly fixed 5h and 1w rows with provider default abbreviations an
   assert.deepEqual(snapshot.rows.map(row => row.period), ['5h', '1w']);
   assert.deepEqual(snapshot.rows[0].blocks.map(block => block.abbreviation), ['C', 'CX']);
   assert.deepEqual(snapshot.rows[1].blocks.map(block => block.abbreviation), ['CX', 'C']);
-  assert.equal(snapshot.rows[0].hiddenCount, 0);
+  assert.equal(Object.hasOwn(snapshot.rows[0], 'hiddenCount'), false);
   assert.deepEqual(snapshot.rows[0].blocks.map(block => Object.hasOwn(block, 'sourceLabel')), [false, false]);
   assert.equal(snapshot.rows[0].blocks[0].elapsedPct, 50);
   assert.match(snapshot.rows[0].blocks[0].resetLabel, /^\d+h/);
@@ -186,7 +186,7 @@ test('orders unconfigured targets by quota risk before applying the default task
     'antigravity.group.model.gemini-danger',
     'antigravity.group.model.gemini-low',
   ]);
-  assert.equal(snapshot.rows[0].hiddenCount, 2);
+  assert.equal(Object.hasOwn(snapshot.rows[0], 'hiddenCount'), false);
 });
 
 test('applies explicit taskbar row block limits between one and three blocks', () => {
@@ -217,11 +217,11 @@ test('applies explicit taskbar row block limits between one and three blocks', (
   const clamped = buildTaskbarQuotaSnapshot(state({ taskbarQuotaMaxBlocks: 99 }, providerQuotas));
 
   assert.equal(one.rows[0].blocks.length, 1);
-  assert.equal(one.rows[0].hiddenCount, 2);
+  assert.equal(Object.hasOwn(one.rows[0], 'hiddenCount'), false);
   assert.equal(three.rows[0].blocks.length, 3);
-  assert.equal(three.rows[0].hiddenCount, 0);
+  assert.equal(Object.hasOwn(three.rows[0], 'hiddenCount'), false);
   assert.equal(clamped.rows[0].blocks.length, 3);
-  assert.equal(clamped.rows[0].hiddenCount, 0);
+  assert.equal(Object.hasOwn(clamped.rows[0], 'hiddenCount'), false);
 });
 
 test('excludes none mode and percent-only Antigravity models without 5h or 1w period', () => {

--- a/src/main/taskbarQuotaSnapshot.ts
+++ b/src/main/taskbarQuotaSnapshot.ts
@@ -25,7 +25,6 @@ export interface TaskbarQuotaSnapshot {
 export interface TaskbarQuotaPeriodRow {
   period: TaskbarQuotaPeriod;
   blocks: TaskbarQuotaBlock[];
-  hiddenCount: number;
   statusLabel: string | null;
 }
 
@@ -359,7 +358,6 @@ export function buildTaskbarQuotaSnapshot(
       return {
         period,
         blocks,
-        hiddenCount: Math.max(0, sorted.length - blocks.length),
         statusLabel: blocks.length > 0 ? null : waiting ? 'waiting' : hiddenPeriods[period] ? 'hidden' : hasOfflineProvider ? 'offline' : 'no data',
       };
     }),

--- a/taskbar-helper/Program.cs
+++ b/taskbar-helper/Program.cs
@@ -78,8 +78,7 @@ internal static class Program
             if (row is null
                 || !ValidTaskbarPeriods.Contains(row.Period)
                 || row.Blocks is null
-                || row.Blocks.Length > 3
-                || row.HiddenCount < 0)
+                || row.Blocks.Length > 3)
             {
                 return false;
             }
@@ -408,7 +407,7 @@ internal static class JsonOptions
 }
 
 internal sealed record TaskbarQuotaSnapshot(long UpdatedAt, string? Theme, TaskbarQuotaPeriodRow[] Rows);
-internal sealed record TaskbarQuotaPeriodRow(string Period, TaskbarQuotaBlock[] Blocks, int HiddenCount = 0, string? StatusLabel = null);
+internal sealed record TaskbarQuotaPeriodRow(string Period, TaskbarQuotaBlock[] Blocks, string? StatusLabel = null);
 internal sealed record LayoutState(int X, int Y);
 internal sealed record TaskbarQuotaBlock(
     string TargetId,
@@ -431,9 +430,9 @@ internal sealed class TaskbarQuotaCanvas : Control
     private const int BlockGap = 6;
     private const int HorizontalPadding = 4;
     private const int VerticalPadding = 2;
-    private const int PeriodWidth = 32;
+    private const int PeriodWidth = 40;
     private const int BlockHorizontalPadding = 2;
-    private const int OverflowBadgeWidth = 24;
+    private const int TextMeasurePadding = 4;
     private const int MinimumBlockWidth = 112;
     private const int MinimumMaximumBlockWidth = 124;
     private const int MaximumMaximumBlockWidth = 260;
@@ -601,22 +600,9 @@ internal sealed class TaskbarQuotaCanvas : Control
         foreach (var row in snapshot.Rows.Take(2))
         {
             var block = row.Blocks.ElementAtOrDefault(blockIndex);
-            if (block is not null)
-            {
-                hasBlock = true;
-                var blockWidth = MeasureBlockWidth(graphics, block, maxBlockWidth);
-                if (row.HiddenCount > 0 && blockIndex == 2)
-                {
-                    blockWidth = Math.Min(maxBlockWidth, blockWidth + Scaled(OverflowBadgeWidth));
-                }
-                width = Math.Max(width, blockWidth);
-                continue;
-            }
-            if (row.HiddenCount > 0 && blockIndex == row.Blocks.Length && blockIndex < 3)
-            {
-                hasBlock = true;
-                width = Math.Max(width, Scaled(OverflowBadgeWidth));
-            }
+            if (block is null) continue;
+            hasBlock = true;
+            width = Math.Max(width, MeasureBlockWidth(graphics, block, maxBlockWidth));
         }
         if (!hasBlock && blockIndex == 0 && snapshot.Rows.Take(2).Any(row => row.Blocks.Length == 0 && !string.IsNullOrWhiteSpace(row.StatusLabel)))
         {
@@ -662,7 +648,7 @@ internal sealed class TaskbarQuotaCanvas : Control
     }
 
     private static int VisibleBlockCount(TaskbarQuotaSnapshot snapshot)
-        => Math.Clamp(snapshot.Rows.Take(2).Select(row => Math.Min(3, row.Blocks.Length + (row.HiddenCount > 0 ? 1 : 0))).DefaultIfEmpty(0).Max(), 1, 3);
+        => Math.Clamp(snapshot.Rows.Take(2).Select(row => row.Blocks.Length).DefaultIfEmpty(0).Max(), 1, 3);
 
     private int MaximumBlockWidthFor(int availableWidth, int visibleBlockCount)
     {
@@ -696,23 +682,7 @@ internal sealed class TaskbarQuotaCanvas : Control
         }
         DrawBlock(graphics, row.Blocks.ElementAtOrDefault(0), RowCell(columns[BlockOneColumn], rowBounds));
         DrawBlock(graphics, row.Blocks.ElementAtOrDefault(1), RowCell(columns[BlockTwoColumn], rowBounds));
-        var thirdCell = RowCell(columns[BlockThreeColumn], rowBounds);
-        if (row.HiddenCount > 0 && row.Blocks.Length < 3)
-        {
-            var badgeColumn = row.Blocks.Length == 1 ? BlockTwoColumn : BlockThreeColumn;
-            DrawOverflowBadge(graphics, row.HiddenCount, RowCell(columns[badgeColumn], rowBounds));
-            return;
-        }
-        if (row.HiddenCount > 0 && thirdCell.Width > 0)
-        {
-            var badgeWidth = Math.Min(Scaled(OverflowBadgeWidth), thirdCell.Width);
-            var blockCell = new Rectangle(thirdCell.Left, thirdCell.Top, Math.Max(0, thirdCell.Width - badgeWidth), thirdCell.Height);
-            var badgeCell = new Rectangle(thirdCell.Right - badgeWidth, thirdCell.Top, badgeWidth, thirdCell.Height);
-            DrawBlock(graphics, row.Blocks.ElementAtOrDefault(2), blockCell);
-            DrawOverflowBadge(graphics, row.HiddenCount, badgeCell);
-            return;
-        }
-        DrawBlock(graphics, row.Blocks.ElementAtOrDefault(2), thirdCell);
+        DrawBlock(graphics, row.Blocks.ElementAtOrDefault(2), RowCell(columns[BlockThreeColumn], rowBounds));
     }
 
     private void DrawBlock(Graphics graphics, TaskbarQuotaBlock? block, Rectangle bounds)
@@ -770,7 +740,7 @@ internal sealed class TaskbarQuotaCanvas : Control
         if (string.IsNullOrEmpty(text) || maxWidth <= 0) return 0;
         using var format = TextStringFormat();
         var measured = graphics.MeasureString(text, font, maxWidth, format);
-        return Math.Min(maxWidth, (int)Math.Ceiling(measured.Width) + Scaled(2));
+        return Math.Min(maxWidth, (int)Math.Ceiling(measured.Width) + Scaled(TextMeasurePadding));
     }
 
     private void DrawText(Graphics graphics, string text, Font font, Color color, Rectangle bounds)
@@ -786,12 +756,6 @@ internal sealed class TaskbarQuotaCanvas : Control
         if (bounds.Width <= 0 || bounds.Height <= 0) return;
         using var brush = new SolidBrush(_palette.Divider);
         graphics.FillRectangle(brush, bounds);
-    }
-
-    private void DrawOverflowBadge(Graphics graphics, int hiddenCount, Rectangle bounds)
-    {
-        if (hiddenCount <= 0 || bounds.Width <= 0 || bounds.Height <= 0) return;
-        DrawText(graphics, $"+{hiddenCount}", _blockFont, _palette.Muted, bounds);
     }
 
     private Rectangle RowCell(Rectangle column, Rectangle rowBounds)
@@ -842,8 +806,8 @@ internal sealed class TaskbarQuotaCanvas : Control
     {
         Alignment = StringAlignment.Near,
         LineAlignment = StringAlignment.Center,
-        FormatFlags = StringFormatFlags.NoWrap,
-        Trimming = StringTrimming.EllipsisCharacter,
+        FormatFlags = StringFormatFlags.NoWrap | StringFormatFlags.MeasureTrailingSpaces,
+        Trimming = StringTrimming.None,
     };
 
     private readonly record struct ColumnLayout(


### PR DESCRIPTION
## Summary
- remove taskbar mini hidden overflow counts from the snapshot and native helper rendering
- add 100% DPI text measurement slack so period and reset labels do not clip at 1080p
- update docs and tests for the no-overflow-badge taskbar contract

## Tests
- npm run build:main
- node --test scripts/taskbar-helper-native.test.mjs
- node --test scripts/provider-settings.test.mjs scripts/taskbar-quota-snapshot.test.mjs scripts/taskbar-helper-manager.test.mjs
- npm run build:taskbar-helper