### PR TITLE
fix: tighten taskbar mini overflow bounds

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -14,7 +14,7 @@ WhereMyTokens is a local-first Windows tray app for AI coding usage observabilit
 - Provider quota cards for Claude, Codex, Antigravity, and future provider adapters.
 - Per-target quota display modes: Rich, Simple, or hidden.
 - Quota Pace compares usage percentage with elapsed reset-window time.
-- Optional draggable Windows taskbar mini quota display with fixed `5h` and `1w` rows, a configurable per-row block limit, hidden-target counts, source/status-colored target prefixes, transparent background, and taskbar-background-aware text contrast.
+- Optional draggable Windows taskbar mini quota display with fixed `5h` and `1w` rows, a configurable per-row block limit, compact measured hidden-target counts, content-fitted window bounds, source/status-colored target prefixes, transparent background, and taskbar-background-aware text contrast.
 - Windows toast notifications for configurable usage thresholds.
 - Claude Code `statusLine` bridge support for live local context and fallback quota data.
 
@@ -39,7 +39,7 @@ WhereMyTokens is a local-first Windows tray app for AI coding usage observabilit
 - USD or KRW display with configurable exchange rate.
 - Tray label modes for usage percentage, token count, or cost.
 - Floating Quota Pace widget with always-on-top support.
-- Windows-only draggable self-contained taskbar mini display for compact `5H` / `1W` quota rows with a configurable block limit, dynamic visible-column sizing, hidden-target counts, source/status-colored target prefixes, and transparent, sampled-background-aware rendering.
+- Windows-only draggable self-contained taskbar mini display for compact `5H` / `1W` quota rows with a configurable block limit, dynamic visible-column sizing, measured hidden-target suffixes, content-fitted hit bounds, source/status-colored target prefixes, and transparent, sampled-background-aware rendering.
 - Dashboard layout controls for hiding or reordering optional cards.
 - Project hide and exclude controls.
 - Optional start with Windows.

--- a/scripts/taskbar-helper-native.test.mjs
+++ b/scripts/taskbar-helper-native.test.mjs
@@ -69,7 +69,33 @@ test('taskbar helper renders compact overflow counts for hidden targets', () => 
   assert.match(source, /HiddenCount/);
   assert.match(source, /DrawOverflowBadge/);
   assert.match(source, /\$"\+\{hiddenCount\}"/);
+  assert.match(source, /MeasureOverflowBadgeWidth/);
+  assert.match(source, /OverflowBadgeHorizontalPadding/);
+  assert.doesNotMatch(source, /OverflowBadgeWidth\s*=\s*\d+/);
   assert.doesNotMatch(source, /SourceLabel/);
+});
+
+test('taskbar helper keeps overflow-only suffix columns at their measured text width', () => {
+  const source = fs.readFileSync(path.resolve('taskbar-helper', 'Program.cs'), 'utf8');
+  const measureColumn = source.match(/private int MeasureColumnWidth[\s\S]*?private int MeasureStatusWidth/)?.[0] ?? '';
+  const finalizeColumn = source.match(/private int FinalizeMeasuredColumnWidth[\s\S]*?private int MeasureOverflowBadgeWidth/)?.[0] ?? '';
+
+  assert.match(measureColumn, /MeasureOverflowBadgeWidth\(graphics,\s*row\.HiddenCount\)/);
+  assert.match(measureColumn, /blockIndex\s*==\s*row\.Blocks\.Length/);
+  assert.match(measureColumn, /FinalizeMeasuredColumnWidth\(width,\s*hasQuotaBlock,\s*maxBlockWidth\)/);
+  assert.match(finalizeColumn, /hasQuotaBlock\s*\?\s*Scaled\(MinimumBlockWidth\)\s*:\s*0/);
+  assert.doesNotMatch(finalizeColumn, /Math\.Max\(Scaled\(MinimumBlockWidth\),\s*measuredWidth\)/);
+});
+
+test('taskbar helper measures one-, two-, and three-block overflow geometry from each row hidden count', () => {
+  const source = fs.readFileSync(path.resolve('taskbar-helper', 'Program.cs'), 'utf8');
+  const measureColumn = source.match(/private int MeasureColumnWidth[\s\S]*?private int MeasureStatusWidth/)?.[0] ?? '';
+  const drawRow = source.match(/private void DrawRow[\s\S]*?private void DrawBlock/)?.[0] ?? '';
+
+  assert.match(measureColumn, /row\.HiddenCount\s*>\s*0\s*&&\s*blockIndex\s*==\s*2[\s\S]*MeasureOverflowBadgeWidth\(graphics,\s*row\.HiddenCount\)/);
+  assert.match(measureColumn, /row\.HiddenCount\s*>\s*0\s*&&\s*blockIndex\s*==\s*row\.Blocks\.Length\s*&&\s*blockIndex\s*<\s*3/);
+  assert.match(drawRow, /row\.Blocks\.Length\s*<\s*3[\s\S]*row\.Blocks\.Length\s*==\s*1\s*\?\s*BlockTwoColumn\s*:\s*BlockThreeColumn/);
+  assert.match(drawRow, /MeasureOverflowBadgeWidth\(graphics,\s*row\.HiddenCount\)/);
 });
 
 test('taskbar helper renders row status text when no quota blocks are available', () => {
@@ -100,12 +126,14 @@ test('taskbar helper validates semantic snapshot arrays before rendering', () =>
 
 test('taskbar helper sizes its host window from measured quota content', () => {
   const source = fs.readFileSync(path.resolve('taskbar-helper', 'Program.cs'), 'utf8');
+  const preferredWidth = source.match(/private int PreferredWidthForTaskbar[\s\S]*?public void Render/)?.[0] ?? '';
   assert.match(source, /MeasurePreferredWidth/);
   assert.match(source, /ResizeToSnapshot/);
   assert.match(source, /RefreshTaskbarMetrics/);
   assert.match(source, /private void ResizeToSnapshot[\s\S]*?!RefreshTaskbarMetrics\(\)/);
   assert.match(source, /PreferredWidthForTaskbar\(taskbarWidth,\s*preferredContentWidth\)/);
-  assert.doesNotMatch(source, /MinimumReadableWidth\s*=\s*780/);
+  assert.match(preferredWidth, /return Math\.Min\(taskbarLimit,\s*Math\.Min\(screenAwareLimit,\s*preferredContentWidth\)\)/);
+  assert.doesNotMatch(preferredWidth, /Math\.Max\([^\n]*preferredContentWidth/);
 });
 
 test('taskbar helper scales layout budgets for the taskbar monitor dpi', () => {
@@ -191,11 +219,14 @@ test('taskbar helper colors only quota used percent by severity', () => {
   assert.match(source, /_palette\.Text/);
 });
 
-test('taskbar helper sizes maximum block width from visible block columns', () => {
+test('taskbar helper sizes maximum block width from quota blocks without counting overflow suffixes', () => {
   const source = fs.readFileSync(path.resolve('taskbar-helper', 'Program.cs'), 'utf8');
-  assert.match(source, /VisibleBlockCount/);
-  assert.match(source, /MaximumBlockWidthFor\(taskbarWidth,\s*VisibleBlockCount\(snapshot\)\)/);
-  assert.match(source, /MaximumBlockWidthFor\(ClientSize\.Width,\s*VisibleBlockCount\(snapshot\)\)/);
+  const visibleCount = source.match(/private static int VisibleQuotaBlockCount[\s\S]*?private int MaximumBlockWidthFor/)?.[0] ?? '';
+  assert.match(source, /VisibleQuotaBlockCount/);
+  assert.match(source, /MaximumBlockWidthFor\(taskbarWidth,\s*VisibleQuotaBlockCount\(snapshot\)\)/);
+  assert.match(source, /MaximumBlockWidthFor\(ClientSize\.Width,\s*VisibleQuotaBlockCount\(snapshot\)\)/);
+  assert.match(visibleCount, /row\.Blocks\.Length/);
+  assert.doesNotMatch(visibleCount, /HiddenCount/);
   assert.match(source, /NonBlockWidthForBlockCount\(blockCount\)/);
   assert.doesNotMatch(source, /MaximumBlockWidthFor\(int availableWidth,\s*int visibleBlockCount\)[\s\S]*\/\s*3/);
 });

--- a/taskbar-helper/Program.cs
+++ b/taskbar-helper/Program.cs
@@ -117,7 +117,7 @@ internal static class Program
 internal sealed class TaskbarQuotaForm : Form
 {
     private const int DefaultPreferredWidth = 520;
-    private const int MinimumReadableWidth = 360;
+    private const int MinimumScreenAwareWidth = 360;
     private const int MaximumPreferredWidth = 920;
     private const int HorizontalHeightPadding = 4;
     private const int VerticalWidthPadding = 8;
@@ -236,9 +236,8 @@ internal sealed class TaskbarQuotaForm : Form
     private int PreferredWidthForTaskbar(int taskbarWidth, int preferredContentWidth)
     {
         var taskbarLimit = Math.Max(Scaled(160), taskbarWidth - Scaled(8));
-        var screenAwareLimit = Math.Min(Scaled(MaximumPreferredWidth), Math.Max(Scaled(MinimumReadableWidth), taskbarWidth / 2));
-        var clampedContentWidth = Math.Max(Scaled(MinimumReadableWidth), preferredContentWidth);
-        return Math.Min(taskbarLimit, Math.Min(screenAwareLimit, clampedContentWidth));
+        var screenAwareLimit = Math.Min(Scaled(MaximumPreferredWidth), Math.Max(Scaled(MinimumScreenAwareWidth), taskbarWidth / 2));
+        return Math.Min(taskbarLimit, Math.Min(screenAwareLimit, preferredContentWidth));
     }
 
     public void Render(TaskbarQuotaSnapshot snapshot)
@@ -433,7 +432,7 @@ internal sealed class TaskbarQuotaCanvas : Control
     private const int VerticalPadding = 2;
     private const int PeriodWidth = 32;
     private const int BlockHorizontalPadding = 2;
-    private const int OverflowBadgeWidth = 24;
+    private const int OverflowBadgeHorizontalPadding = 1;
     private const int MinimumBlockWidth = 112;
     private const int MinimumMaximumBlockWidth = 124;
     private const int MaximumMaximumBlockWidth = 260;
@@ -478,7 +477,7 @@ internal sealed class TaskbarQuotaCanvas : Control
     public int MeasurePreferredWidth(TaskbarQuotaSnapshot snapshot, int taskbarWidth)
     {
         using var graphics = CreateGraphics();
-        var maxBlockWidth = MaximumBlockWidthFor(taskbarWidth, VisibleBlockCount(snapshot));
+        var maxBlockWidth = MaximumBlockWidthFor(taskbarWidth, VisibleQuotaBlockCount(snapshot));
         var blockWidths = MeasureColumnWidths(graphics, snapshot, maxBlockWidth);
         return (Scaled(HorizontalPadding) * 2) + MeasureContentWidth(blockWidths);
     }
@@ -532,7 +531,7 @@ internal sealed class TaskbarQuotaCanvas : Control
         var period = new Rectangle(content.Left, content.Top, Scaled(PeriodWidth), content.Height);
         var periodDivider = new Rectangle(period.Right, content.Top, Scaled(DividerWidth), content.Height);
 
-        var blockWidths = FitBlockWidths(MeasureColumnWidths(graphics, snapshot, MaximumBlockWidthFor(ClientSize.Width, VisibleBlockCount(snapshot))), content.Width);
+        var blockWidths = FitBlockWidths(MeasureColumnWidths(graphics, snapshot, MaximumBlockWidthFor(ClientSize.Width, VisibleQuotaBlockCount(snapshot))), content.Width);
         var blockOneWidth = blockWidths[0];
         var blockTwoWidth = blockWidths[1];
         var blockThreeWidth = blockWidths[2];
@@ -597,33 +596,44 @@ internal sealed class TaskbarQuotaCanvas : Control
     private int MeasureColumnWidth(Graphics graphics, TaskbarQuotaSnapshot snapshot, int blockIndex, int maxBlockWidth)
     {
         var width = 0;
-        var hasBlock = false;
+        var hasQuotaBlock = false;
         foreach (var row in snapshot.Rows.Take(2))
         {
             var block = row.Blocks.ElementAtOrDefault(blockIndex);
             if (block is not null)
             {
-                hasBlock = true;
+                hasQuotaBlock = true;
                 var blockWidth = MeasureBlockWidth(graphics, block, maxBlockWidth);
                 if (row.HiddenCount > 0 && blockIndex == 2)
                 {
-                    blockWidth = Math.Min(maxBlockWidth, blockWidth + Scaled(OverflowBadgeWidth));
+                    blockWidth = Math.Min(maxBlockWidth, blockWidth + MeasureOverflowBadgeWidth(graphics, row.HiddenCount));
                 }
                 width = Math.Max(width, blockWidth);
                 continue;
             }
             if (row.HiddenCount > 0 && blockIndex == row.Blocks.Length && blockIndex < 3)
             {
-                hasBlock = true;
-                width = Math.Max(width, Scaled(OverflowBadgeWidth));
+                width = Math.Max(width, MeasureOverflowBadgeWidth(graphics, row.HiddenCount));
             }
         }
-        if (!hasBlock && blockIndex == 0 && snapshot.Rows.Take(2).Any(row => row.Blocks.Length == 0 && !string.IsNullOrWhiteSpace(row.StatusLabel)))
+        if (!hasQuotaBlock && blockIndex == 0 && snapshot.Rows.Take(2).Any(row => row.Blocks.Length == 0 && !string.IsNullOrWhiteSpace(row.StatusLabel)))
         {
             return Math.Min(maxBlockWidth, Math.Max(Scaled(MinimumBlockWidth), MeasureStatusWidth(graphics, snapshot, maxBlockWidth)));
         }
-        if (!hasBlock) return 0;
-        return Math.Min(maxBlockWidth, Math.Max(Scaled(MinimumBlockWidth), width));
+        if (width <= 0) return 0;
+        return FinalizeMeasuredColumnWidth(width, hasQuotaBlock, maxBlockWidth);
+    }
+
+    private int FinalizeMeasuredColumnWidth(int measuredWidth, bool hasQuotaBlock, int maxBlockWidth)
+    {
+        var minimumWidth = hasQuotaBlock ? Scaled(MinimumBlockWidth) : 0;
+        return Math.Min(maxBlockWidth, Math.Max(minimumWidth, measuredWidth));
+    }
+
+    private int MeasureOverflowBadgeWidth(Graphics graphics, int hiddenCount)
+    {
+        var textWidth = MeasureDrawStringWidth(graphics, $"+{hiddenCount}", _blockFont, Scaled(MaximumMaximumBlockWidth));
+        return textWidth + (Scaled(OverflowBadgeHorizontalPadding) * 2);
     }
 
     private int MeasureStatusWidth(Graphics graphics, TaskbarQuotaSnapshot snapshot, int maxBlockWidth)
@@ -661,8 +671,8 @@ internal sealed class TaskbarQuotaCanvas : Control
         return width;
     }
 
-    private static int VisibleBlockCount(TaskbarQuotaSnapshot snapshot)
-        => Math.Clamp(snapshot.Rows.Take(2).Select(row => Math.Min(3, row.Blocks.Length + (row.HiddenCount > 0 ? 1 : 0))).DefaultIfEmpty(0).Max(), 1, 3);
+    private static int VisibleQuotaBlockCount(TaskbarQuotaSnapshot snapshot)
+        => Math.Clamp(snapshot.Rows.Take(2).Select(row => Math.Min(3, row.Blocks.Length)).DefaultIfEmpty(0).Max(), 1, 3);
 
     private int MaximumBlockWidthFor(int availableWidth, int visibleBlockCount)
     {
@@ -705,7 +715,7 @@ internal sealed class TaskbarQuotaCanvas : Control
         }
         if (row.HiddenCount > 0 && thirdCell.Width > 0)
         {
-            var badgeWidth = Math.Min(Scaled(OverflowBadgeWidth), thirdCell.Width);
+            var badgeWidth = Math.Min(MeasureOverflowBadgeWidth(graphics, row.HiddenCount), thirdCell.Width);
             var blockCell = new Rectangle(thirdCell.Left, thirdCell.Top, Math.Max(0, thirdCell.Width - badgeWidth), thirdCell.Height);
             var badgeCell = new Rectangle(thirdCell.Right - badgeWidth, thirdCell.Top, badgeWidth, thirdCell.Height);
             DrawBlock(graphics, row.Blocks.ElementAtOrDefault(2), blockCell);
@@ -791,7 +801,9 @@ internal sealed class TaskbarQuotaCanvas : Control
     private void DrawOverflowBadge(Graphics graphics, int hiddenCount, Rectangle bounds)
     {
         if (hiddenCount <= 0 || bounds.Width <= 0 || bounds.Height <= 0) return;
-        DrawText(graphics, $"+{hiddenCount}", _blockFont, _palette.Muted, bounds);
+        var horizontalPadding = Math.Min(Scaled(OverflowBadgeHorizontalPadding), bounds.Width / 2);
+        var contentBounds = Rectangle.Inflate(bounds, -horizontalPadding, 0);
+        DrawText(graphics, $"+{hiddenCount}", _blockFont, _palette.Muted, contentBounds);
     }
 
     private Rectangle RowCell(Rectangle column, Rectangle rowBounds)


### PR DESCRIPTION
## What changed

- measure each hidden-target `+N` suffix from the exact text that is drawn
- keep overflow-only suffix columns out of quota-block minimum width and equal-share budgeting
- size the helper host window to measured content instead of forcing a 360px minimum
- preserve the existing compact suffix behavior for one, two, and three visible quota blocks
- strengthen native source-contract coverage and document content-fitted hit bounds

## Root cause

The overflow cue introduced by `1392842` entered the normal quota-column sizing path. A 24px overflow-only slot was therefore raised to the 112px quota-block minimum, counted as a full block for width budgeting, and then hosted in a window that was forced to at least 360px. Because the WinForms canvas fills the entire helper client area, the visually transparent remainder still intercepted taskbar and tray clicks.

## Impact

The `+N` cue remains visible, but the Form, canvas, and HWND now end immediately after the measured content and trailing padding. Taskbar space to the right of the helper is no longer covered by a transparent helper hit region.

This branch is independent of UsageIndex PR #40 and does not modify UsageIndex code.

## Validation

- `node --test scripts/taskbar-helper-native.test.mjs` — 26/26 passed
- `npm test` — 637/637 passed
- `npm run build:taskbar-helper` — self-contained win-x64 helper published successfully
- Windows `dist` — installer, portable executable, unpacked app, and packaged helper built and signed successfully with publishing disabled
- packaged helper synthetic HWND checks:
  - one block, `+1/+2`: 193px
  - one block, `+1/+12`: 199px
  - two blocks, `+1/+12`: 321px
  - three blocks, `+1/+12`: 431px
  - Form and canvas matched in every case; 2px outside the right edge no longer hit the helper process
- full packaged app check on the same machine: helper width reduced from 417px to 323px for the current user snapshot
