### PR TITLE
Update the macOS 1.1.0 release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ WhereMyTokens is a local-first desktop app for monitoring AI coding usage: quota
 | Windows 10/11 | **[Installer (.exe)](https://github.com/jeongwookie/WhereMyTokens/releases/download/v1.22.0/WhereMyTokens-Setup.exe)** | Normal installation, auto-start from the tray |
 | Windows 10/11 — 日本語 UI | **[Japanese UI installer](https://github.com/jeongwookie/WhereMyTokens/releases/download/v1.22.0/WhereMyTokens-Setup.exe)** | Same installer; Japanese Windows opens in Japanese automatically, or choose Settings → General → Language |
 | Windows 10/11 | **[Portable ZIP](https://github.com/jeongwookie/WhereMyTokens/releases/download/v1.22.0/WhereMyTokens-v1.22.0-win-x64.zip)** | No installer, keep it anywhere |
-| macOS Apple Silicon | **[macOS Edition](https://github.com/jeongwookie/WhereMyTokens-mac/releases/tag/mac-v1.0.0)** | Menu bar app with DMG/ZIP packaging |
+| macOS Apple Silicon | **[macOS Edition](https://github.com/jeongwookie/WhereMyTokens-mac/releases/tag/mac-v1.1.0)** | Menu bar app with DMG/ZIP packaging |
 
 Looking for the menu bar version? See the separate [WhereMyTokens for macOS repository](https://github.com/jeongwookie/WhereMyTokens-mac), which has its own `mac-vX.Y.Z` release track and DMG/ZIP downloads.
 


### PR DESCRIPTION
## What changed

- update the Windows README download table to point to the new macOS `mac-v1.1.0` release

## Why

The macOS edition has moved from `mac-v1.0.0` to `mac-v1.1.0`, so the Windows repository should direct Apple Silicon users to the current DMG/ZIP release.

## Validation

- Windows build completed successfully
- 49 README/settings/static regression tests passed
- `git diff --check` passed
