### PR TITLE
fix: refresh expired Claude token before the usage fetch

### DIFF
--- a/scripts/rate-limit-fetcher.test.mjs
+++ b/scripts/rate-limit-fetcher.test.mjs
@@ -1,12 +1,46 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 import rateLimitFetcher from '../dist/main/rateLimitFetcher.js';
 import claudeQuota from '../dist/main/providers/claude/quota.js';
+import oauthRefresh from '../dist/main/oauthRefresh.js';
 
-const { parseClaudeUsagePayload } = rateLimitFetcher;
+const { parseClaudeUsagePayload, fetchClaudeUsage, __setClaudeUsageHttpForTest } = rateLimitFetcher;
 const { parseClaudeQuotaEntries } = claudeQuota;
+const { __setOAuthRefreshPostForTest, __clearOAuthRefreshForTest } = oauthRefresh;
 const fixture = JSON.parse(fs.readFileSync(new URL('./fixtures/quota/claude-limits.json', import.meta.url), 'utf8'));
+
+const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+const tempDirs = [];
+
+function useTempClaudeCredentials(oauth = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmt-rate-limit-fetcher-'));
+  tempDirs.push(dir);
+  process.env.CLAUDE_CONFIG_DIR = dir;
+  fs.writeFileSync(path.join(dir, '.credentials.json'), JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'stored-access',
+      refreshToken: 'stored-refresh',
+      expiresAt: Date.now() + 3600_000,
+      rateLimitTier: 'max_5x',
+      subscriptionType: 'max',
+      ...oauth,
+    },
+  }, null, 2));
+  return dir;
+}
+
+test.afterEach(() => {
+  __setClaudeUsageHttpForTest(null);
+  __clearOAuthRefreshForTest();
+  if (originalClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test('Claude usage normalizes top-level account windows and retains scoped limits', () => {
   const usage = parseClaudeUsagePayload(fixture, 'max');
@@ -72,4 +106,100 @@ test('Claude reports malformed top-level account windows as invalid candidates',
   assert.equal(usage.accountWindowCandidates, 1);
   assert.equal(usage.invalidAccountWindows, 1);
   assert.deepEqual(parseClaudeQuotaEntries(usage), { entries: [], activeCandidates: 1, invalid: 1 });
+});
+
+test('expired local token refreshes before the usage fetch even when the server would answer 429', async () => {
+  useTempClaudeCredentials({ expiresAt: Date.now() - 60_000 });
+  __setOAuthRefreshPostForTest(async () => ({
+    status: 200,
+    body: JSON.stringify({ access_token: 'fresh-access', refresh_token: 'fresh-refresh', expires_in: 3600 }),
+  }));
+  const seenAuthHeaders = [];
+  __setClaudeUsageHttpForTest(async (_url, headers) => {
+    seenAuthHeaders.push(headers.Authorization);
+    return { status: 200, body: JSON.stringify({ five_hour: fixture.five_hour, seven_day: fixture.seven_day, limits: [] }), headers: {} };
+  });
+
+  const result = await fetchClaudeUsage();
+
+  assert.equal(result.status.code, 'ok');
+  assert.equal(result.status.connected, true);
+  assert.deepEqual(seenAuthHeaders, ['Bearer fresh-access']);
+  assert.equal(result.usage.accountWindows.fiveHour.usedPct, 99);
+});
+
+test('expired local token with a server-rejected refresh reports login required without a usage request', async () => {
+  useTempClaudeCredentials({ expiresAt: Date.now() - 60_000 });
+  __setOAuthRefreshPostForTest(async () => ({
+    status: 400,
+    body: JSON.stringify({ error: 'invalid_grant', error_description: 'Refresh token not found or invalid' }),
+  }));
+  let usageCalls = 0;
+  __setClaudeUsageHttpForTest(async () => {
+    usageCalls += 1;
+    return { status: 429, body: JSON.stringify({ error: { type: 'rate_limit_error', message: 'Rate limited.' } }), headers: {} };
+  });
+
+  const result = await fetchClaudeUsage();
+
+  assert.equal(result.status.code, 'unauthorized');
+  assert.equal(result.status.label, 'login required');
+  assert.equal(result.usage, null);
+  assert.equal(usageCalls, 0);
+});
+
+test('token entering the expiry leeway is renewed proactively before it expires', async () => {
+  useTempClaudeCredentials({ expiresAt: Date.now() + 2 * 60_000 });
+  __setOAuthRefreshPostForTest(async () => ({
+    status: 200,
+    body: JSON.stringify({ access_token: 'fresh-access', refresh_token: 'fresh-refresh', expires_in: 3600 }),
+  }));
+  const seenAuthHeaders = [];
+  __setClaudeUsageHttpForTest(async (_url, headers) => {
+    seenAuthHeaders.push(headers.Authorization);
+    return { status: 200, body: JSON.stringify({ limits: [] }), headers: {} };
+  });
+
+  const result = await fetchClaudeUsage();
+
+  assert.equal(result.status.code, 'ok');
+  assert.deepEqual(seenAuthHeaders, ['Bearer fresh-access']);
+});
+
+test('valid local token fetches usage directly without touching the OAuth refresh endpoint', async () => {
+  useTempClaudeCredentials({ expiresAt: Date.now() + 3600_000 });
+  let refreshCalls = 0;
+  __setOAuthRefreshPostForTest(async () => {
+    refreshCalls += 1;
+    return { status: 200, body: JSON.stringify({ access_token: 'fresh-access', expires_in: 3600 }) };
+  });
+  const seenAuthHeaders = [];
+  __setClaudeUsageHttpForTest(async (_url, headers) => {
+    seenAuthHeaders.push(headers.Authorization);
+    return { status: 200, body: JSON.stringify({ limits: [] }), headers: {} };
+  });
+
+  const result = await fetchClaudeUsage();
+
+  assert.equal(result.status.code, 'ok');
+  assert.equal(refreshCalls, 0);
+  assert.deepEqual(seenAuthHeaders, ['Bearer stored-access']);
+});
+
+test('expired local token with a rate-limited refresh still attempts the fetch with the stored token', async () => {
+  useTempClaudeCredentials({ expiresAt: Date.now() - 60_000 });
+  __setOAuthRefreshPostForTest(async () => ({
+    status: 429,
+    body: JSON.stringify({ error: { message: 'Rate limited. Please try again later.' } }),
+  }));
+  const seenAuthHeaders = [];
+  __setClaudeUsageHttpForTest(async (_url, headers) => {
+    seenAuthHeaders.push(headers.Authorization);
+    return { status: 429, body: JSON.stringify({ error: { type: 'rate_limit_error', message: 'Rate limited.' } }), headers: {} };
+  });
+
+  const result = await fetchClaudeUsage();
+
+  assert.equal(result.status.code, 'rate-limited');
+  assert.deepEqual(seenAuthHeaders, ['Bearer stored-access']);
 });

--- a/src/main/rateLimitFetcher.ts
+++ b/src/main/rateLimitFetcher.ts
@@ -182,7 +182,15 @@ function logStatus(status: ClaudeApiStatus): void {
   });
 }
 
-function httpsGet(url: string, headers: Record<string, string>): Promise<string> {
+interface UsageHttpResponse {
+  status: number;
+  body: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+type UsageHttpGet = (url: string, headers: Record<string, string>) => Promise<UsageHttpResponse>;
+
+function httpsGet(url: string, headers: Record<string, string>): Promise<UsageHttpResponse> {
   return new Promise((resolve, reject) => {
     const u = new URL(url);
     let settled = false;
@@ -214,12 +222,7 @@ function httpsGet(url: string, headers: Record<string, string>): Promise<string>
         res.on('end', () => {
           if (settled) return;
           settled = true;
-          const statusCode = res.statusCode ?? 0;
-          if (statusCode >= 200 && statusCode < 300) {
-            resolve(body);
-            return;
-          }
-          reject(new HttpResponseError(statusCode, body, res.headers));
+          resolve({ status: res.statusCode ?? 0, body, headers: res.headers });
         });
       },
     );
@@ -229,6 +232,12 @@ function httpsGet(url: string, headers: Record<string, string>): Promise<string>
     });
     req.end();
   });
+}
+
+let httpsGetImpl: UsageHttpGet = httpsGet;
+
+export function __setClaudeUsageHttpForTest(impl: UsageHttpGet | null): void {
+  httpsGetImpl = impl ?? httpsGet;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -391,15 +400,18 @@ function planFromTier(tier: string, sub: string): string {
 }
 
 async function performUsageFetch(cred: Credentials): Promise<ApiUsageFetchResult> {
-  const body = await httpsGet('https://api.anthropic.com/api/oauth/usage', {
+  const response = await httpsGetImpl('https://api.anthropic.com/api/oauth/usage', {
     Authorization: `Bearer ${cred.accessToken}`,
     'Content-Type': 'application/json',
     'anthropic-version': '2023-06-01',
     'anthropic-beta': 'oauth-2025-04-20',
     'User-Agent': CLAUDE_USER_AGENT,
   });
+  if (response.status < 200 || response.status >= 300) {
+    throw new HttpResponseError(response.status, response.body, response.headers);
+  }
 
-  const parsed = JSON.parse(body) as unknown;
+  const parsed = JSON.parse(response.body) as unknown;
   const data = asRecord(parsed);
   if (!data) {
     const status = buildStatus('schema-changed', false, 'schema changed', 'Claude API returned a non-object response.');
@@ -472,6 +484,11 @@ function refreshFailedStatus(outcome: Extract<RefreshOutcome, { kind: 'network' 
   );
 }
 
+function credentialLooksExpired(): boolean {
+  const state = getOAuthCredentialState();
+  return state.isExpired || (state.msUntilExpiry != null && state.msUntilExpiry < 60_000);
+}
+
 export async function fetchClaudeUsage(): Promise<ApiUsageFetchResult> {
   const cred = readCredentials();
   if (!cred) {
@@ -480,13 +497,29 @@ export async function fetchClaudeUsage(): Promise<ApiUsageFetchResult> {
     return { usage: null, status };
   }
 
+  // Token expiry must be detected locally: the server may answer an expired
+  // token with 429 instead of 401, which would otherwise back off forever
+  // without refreshing. Polling doubles as the refresh scheduler, so a token
+  // entering its expiry leeway is renewed here before it actually expires.
+  let accessToken = cred.accessToken;
+  if (getOAuthCredentialState().shouldRefresh) {
+    const outcome = await refreshNow(CLAUDE_OAUTH_REFRESH_USER_AGENT, 'expiry-preflight');
+    if (outcome.kind === 'ok') {
+      accessToken = outcome.accessToken;
+    } else if (outcome.kind === 'invalid-grant') {
+      const status = loginRequiredStatus(outcome.serverMessage);
+      logStatus(status);
+      return { usage: null, status };
+    }
+    // rate-limited / network / write-failed / unexpected: attempt the fetch
+    // with the stored token anyway; the server stays the validity authority.
+  }
+
   try {
-    return await performUsageFetch(cred);
+    return await performUsageFetch({ ...cred, accessToken });
   } catch (error) {
     if (error instanceof HttpResponseError && error.statusCode === 401) {
-      const state = getOAuthCredentialState();
-      const looksLikeExpiredToken = state.isExpired || (state.msUntilExpiry != null && state.msUntilExpiry < 60_000);
-      if (!looksLikeExpiredToken) {
+      if (!credentialLooksExpired()) {
         const status = classifyHttpError(error);
         logStatus(status);
         return { usage: null, status };


### PR DESCRIPTION
## Problem

The Claude 5h quota panel can vanish and never come back until the app is restarted or re-logged-in.

Root cause: the OAuth usage endpoint is not obligated to answer an expired access token with 401 — in practice it can return 429 first. The refresh flow only triggered from the 401 retry branch, so an expired token entered the rate-limited backoff loop and was **never refreshed**. The quota panel then served aging cache until each entry''s `resetsAt` passed — the 5h window expires first, so it disappears first — while the user was shown "rate limited" instead of the truth.

## Fix

Detect expiry locally instead of trusting server status codes:

- Before each usage fetch, a token inside its 5-minute expiry leeway is renewed via `refreshNow()`, whose existing cooldown ladder already bounds retry pressure. Since polling runs every 5 minutes, this doubles as proactive scheduled refresh — the token no longer reaches expiry at all.
- A server-rejected refresh (`invalid_grant`) now surfaces the red "login required" status immediately instead of hiding behind backoff.
- The 401 retry branch stays as the fallback for tokens the server rejects early.

## Verification

- Adds a test seam for the usage HTTP layer plus regressions covering: expired-token refresh, proactive leeway renewal, invalid-grant login prompt, rate-limited refresh fallthrough, and the no-refresh happy path.
- `node --test scripts/rate-limit-fetcher.test.mjs scripts/oauth-refresh.test.mjs`: 18/18 pass.
- Full suite: 441/444 — the 3 failures are the pre-existing time-fragile usage-index tests fixed separately in #48, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)